### PR TITLE
Removes URL pinning

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,15 +1,7 @@
 [build]
   base = "site"
   publish = "public"
+  command = "git submodule update --init && hugo --gc --minify"
 
 [build.environment]
   HUGO_VERSION = "0.85.0"
-
-[context.production]
-  command = "git submodule update --init && hugo --gc --minify"
-
-[context.deploy-preview]
-  command = "git submodule update --init && hugo --gc --minify -b $DEPLOY_PRIME_URL"
-
-[context.branch-deploy]
-  command = "git submodule update --init && hugo --gc --minify -b $DEPLOY_PRIME_URL"


### PR DESCRIPTION
It is possible this will allow https://func-e.netlify.app/ to work until func-e.io DNS propagates.. It is also possible it won't!


interestingly docs argue whether this is even needed or not.
* netlify->hugo leaves it out https://docs.netlify.com/configure-builds/common-configurations/hugo/
* hugo->netlify puts it in https://gohugo.io/hosting-and-deployment/hosting-on-netlify/
