### PR TITLE
Removes unnecessary redirect

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ func-e (pronounced funky) makes running [Envoy®](https://www.envoyproxy.io/) ea
 The quickest way to try the command-line interface is an in-lined configuration.
 ```bash
 # Download the latest release as /usr/local/bin/func-e https://github.com/tetratelabs/func-e/releases
-$ curl -L https://func-e.io/install.sh | bash -s -- -b /usr/local/bin
+$ curl https://func-e.io/install.sh | bash -s -- -b /usr/local/bin
 # Run the admin server on http://localhost:9901
 $ func-e run --config-yaml "admin: {address: {socket_address: {address: '127.0.0.1', port_value: 9901}}}"
 ```

--- a/site/content/index.md
+++ b/site/content/index.md
@@ -7,7 +7,7 @@ configuration you would use in production. Each time you end a run, a snapshot o
 your behalf. This makes knowledge sharing and troubleshooting easier, especially when upgrading. Try it out!
 
 ```sh
-$ curl -L https://func-e.io/install.sh | bash -s -- -b /usr/local/bin
+$ curl https://func-e.io/install.sh | bash -s -- -b /usr/local/bin
 $ func-e run -c /path/to/envoy.yaml
 # If you don't have a configuration file, you can start the admin port like this
 $ func-e run --config-yaml "admin: {address: {socket_address: {address: '127.0.0.1', port_value: 9901}}}"


### PR DESCRIPTION
we serve install.sh directly from the CDN, so there's no need to add complicated flags