### PR TITLE
Fixes skip config

### DIFF
--- a/.github/workflows/commit.yaml
+++ b/.github/workflows/commit.yaml
@@ -12,11 +12,19 @@ on:
   push:
     tags: ''
     branches: master
-    paths-ignore: 'site/**'
+    paths-ignore:  # ignore docs as they are built with Netlify. Ignore travis-related changes, too.
+      - '**/*.md'
+      - 'site/**'
+      - 'netlify.toml'
+      - '.travis.yml'
   # We also run tests on pull requests targeted at the master branch.
   pull_request:
     branches: master
-    paths-ignore: 'site/**'
+    paths-ignore:
+      - '**/*.md'
+      - 'site/**'
+      - 'netlify.toml'
+      - '.travis.yml'
   # workflow_dispatch will let us manually trigger the workflow from GitHub actions dashboard.
   # For example, you can try to build a branch without raising a pull request.
   # See https://docs.github.com/en/free-pro-team@latest/actions/managing-workflow-runs/manually-running-a-workflow

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ git:
 before_install: |  # Prevent test build of a documentation or GitHub Actions only change.
   make check || travis_terminate 1
   if [ -n "${TRAVIS_COMMIT_RANGE}" ] && ! git diff --name-only "${TRAVIS_COMMIT_RANGE}" -- \
-    grep -qvE '(\.md)$|^(site\/)|^(netlify.toml)|^(.github\/)' | grep -qv '\.md$'; then
+    grep -qvE '(\.md)$|^(site\/)|^(netlify.toml)|^(.github\/)'; then
     echo "Stopping job as changes only affect documentation (ex. README.md)"
     travis_terminate 0
   fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,9 +12,10 @@ go:
 git:
   depth: false  # TRAVIS_COMMIT_RANGE requires full commit history.
 
-before_install: |  # Prevent test build of a documentation-only change.
+before_install: |  # Prevent test build of a documentation or GitHub Actions only change.
   make check || travis_terminate 1
-  if [ -n "${TRAVIS_COMMIT_RANGE}" ] && ! git diff --name-only "${TRAVIS_COMMIT_RANGE}" -- | grep -qv '\.md$'; then
+  if [ -n "${TRAVIS_COMMIT_RANGE}" ] && ! git diff --name-only "${TRAVIS_COMMIT_RANGE}" -- \
+    grep -qvE '(\.md)$|^(site\/)|^(netlify.toml)|^(.github\/)' | grep -qv '\.md$'; then
     echo "Stopping job as changes only affect documentation (ex. README.md)"
     travis_terminate 0
   fi


### PR DESCRIPTION
This prevents CI-only changes from tripping each other. It also skips more doc related stuff. Doing so will help conserve our free arm64 credits for real change.

AFAICT netlify will skip when it should anyway https://docs.netlify.com/configure-builds/file-based-configuration/#ignore-builds