### PR TITLE
Optimizes Travis check

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,14 +9,21 @@ language: go
 go:
   - 1.16.5
 
+cache:
+  directories: # ~/.func-e/versions is cached so that we only re-download once: for TestFuncEInstall
+    - $HOME/.func-e/versions
+    - $HOME/go/pkg/mod
+    - $HOME/go/bin/*-v*
+
 git:
   depth: false  # TRAVIS_COMMIT_RANGE requires full commit history.
 
 before_install: |  # Prevent test build of a documentation or GitHub Actions only change.
-  make check || travis_terminate 1
   if [ -n "${TRAVIS_COMMIT_RANGE}" ] && ! git diff --name-only "${TRAVIS_COMMIT_RANGE}" -- \
     grep -qvE '(\.md)$|^(site\/)|^(netlify.toml)|^(.github\/)'; then
     echo "Stopping job as changes only affect documentation (ex. README.md)"
     travis_terminate 0
   fi
+  make check || travis_terminate 1
+
 script: make e2e


### PR DESCRIPTION
This does two things to conserve arm64 time.
 * run `make check` *after* checking if the build should run!
 * cache the same directories we do in GH actions
