### PR TITLE
Adds FUNC_E_PLATFORM to override host OS and architecture used to run Envoy

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -10,6 +10,10 @@ You may want to override `$ENVOY_VERSIONS_URL` to supply custom builds or
 otherwise control the source of Envoy binaries. When overriding, validate
 your JSON first: https://archive.tetratelabs.io/release-versions-schema.json
 
+Advanced:
+`FUNC_E_PLATFORM` overrides the host OS and architecture of Envoy binaries.
+This value must be constant within a `$FUNC_E_HOME`.
+
 # Commands
 
 | Name | Usage |
@@ -26,3 +30,4 @@ your JSON first: https://archive.tetratelabs.io/release-versions-schema.json
 | ---- | ----- | ------- |
 | FUNC_E_HOME | func-e home directory (location of installed versions and run archives) | ${HOME}/.func-e |
 | ENVOY_VERSIONS_URL | URL of Envoy versions JSON | https://archive.tetratelabs.io/envoy/envoy-versions.json |
+| FUNC_E_PLATFORM | the host OS and architecture of Envoy binaries. Ex. darwin/arm64 | $GOOS/$GOARCH |

--- a/internal/cmd/run.go
+++ b/internal/cmd/run.go
@@ -71,7 +71,7 @@ state. On exit, these archive into ` + "`$FUNC_E_HOME/runs/$epochtime.tar.gz`",
 			return nil
 		},
 		Action: func(c *cli.Context) error {
-			if err := initializeRunOpts(c.Context, o, globals.CurrentPlatform, envoyVersion); err != nil {
+			if err := initializeRunOpts(c.Context, o, envoyVersion); err != nil {
 				return err
 			}
 			r := envoy.NewRuntime(&o.RunOpts)
@@ -111,10 +111,10 @@ state. On exit, these archive into ` + "`$FUNC_E_HOME/runs/$epochtime.tar.gz`",
 // initializeRunOpts allows us to default values when not overridden for tests.
 // The version parameter correlates with the globals.GlobalOpts EnvoyPath which is installed if needed.
 // Notably, this creates and sets a globals.GlobalOpts WorkingDirectory for Envoy, and any files that precede it.
-func initializeRunOpts(ctx context.Context, o *globals.GlobalOpts, p version.Platform, v version.Version) error {
+func initializeRunOpts(ctx context.Context, o *globals.GlobalOpts, v version.Version) error {
 	runOpts := &o.RunOpts
 	if o.EnvoyPath == "" { // not overridden for tests
-		envoyPath, err := envoy.InstallIfNeeded(ctx, o, p, v)
+		envoyPath, err := envoy.InstallIfNeeded(ctx, o, v)
 		if err != nil {
 			return err
 		}
@@ -144,7 +144,7 @@ func setHomeEnvoyVersion(ctx context.Context, o *globals.GlobalOpts) error {
 
 	// First time install: look up the latest version, which may be newer than version.LastKnownEnvoy!
 	fmt.Fprintln(o.Out, "looking up latest version") //nolint
-	m, err := envoy.FuncEVersions(ctx, o.EnvoyVersionsURL, globals.CurrentPlatform, o.Version)
+	m, err := envoy.FuncEVersions(ctx, o.EnvoyVersionsURL, o.Platform, o.Version)
 	if err != nil {
 		return NewValidationError(`couldn't read latest version from %s: %s`, o.EnvoyVersionsURL, err)
 	}

--- a/internal/cmd/testdata/func-e_help.txt
+++ b/internal/cmd/testdata/func-e_help.txt
@@ -13,6 +13,10 @@ USAGE:
    otherwise control the source of Envoy binaries. When overriding, validate
    your JSON first: https://archive.tetratelabs.io/release-versions-schema.json
 
+   Advanced:
+   `FUNC_E_PLATFORM` overrides the host OS and architecture of Envoy binaries.
+   This value must be constant within a `$FUNC_E_HOME`.
+
 VERSION:
    1.0
 
@@ -25,4 +29,5 @@ COMMANDS:
 GLOBAL OPTIONS:
    --home-dir value            func-e home directory (location of installed versions and run archives) (default: ${HOME}/.func-e) [$FUNC_E_HOME]
    --envoy-versions-url value  URL of Envoy versions JSON (default: https://archive.tetratelabs.io/envoy/envoy-versions.json) [$ENVOY_VERSIONS_URL]
+   --platform value            the host OS and architecture of Envoy binaries. Ex. darwin/arm64 (default: $GOOS/$GOARCH) [$FUNC_E_PLATFORM]
    --version, -v               print the version (default: false)

--- a/internal/cmd/use.go
+++ b/internal/cmd/use.go
@@ -44,7 +44,7 @@ $ func-e use %s`, envoy.CurrentVersionWorkingDirFile, envoy.CurrentVersionHomeDi
 		Before: validateVersionArg,
 		Action: func(c *cli.Context) error {
 			v := version.Version(c.Args().First())
-			if _, err := envoy.InstallIfNeeded(c.Context, o, globals.CurrentPlatform, v); err != nil {
+			if _, err := envoy.InstallIfNeeded(c.Context, o, v); err != nil {
 				return err
 			}
 			return envoy.WriteCurrentVersion(v, o.HomeDir)

--- a/internal/cmd/versions.go
+++ b/internal/cmd/versions.go
@@ -50,9 +50,9 @@ func NewVersionsCmd(o *globals.GlobalOpts) *cli.Command {
 			currentVersion, currentVersionSource, _ := envoy.CurrentVersion(o.HomeDir)
 
 			if c.Bool("all") {
-				if ev, err := envoy.FuncEVersions(c.Context, o.EnvoyVersionsURL, globals.CurrentPlatform, o.Version); err != nil {
+				if ev, err := envoy.FuncEVersions(c.Context, o.EnvoyVersionsURL, o.Platform, o.Version); err != nil {
 					return err
-				} else if err := addAvailableVersions(&rows, ev.Versions, globals.CurrentPlatform); err != nil {
+				} else if err := addAvailableVersions(&rows, ev.Versions, o.Platform); err != nil {
 					return err
 				}
 			}

--- a/internal/envoy/http_test.go
+++ b/internal/envoy/http_test.go
@@ -33,7 +33,7 @@ func TestHttpGet_AddsDefaultHeaders(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	res, err := httpGet(context.Background(), ts.URL, globals.CurrentPlatform, "dev")
+	res, err := httpGet(context.Background(), ts.URL, globals.DefaultPlatform, "dev")
 	require.NoError(t, err)
 
 	defer res.Body.Close()

--- a/internal/globals/globals.go
+++ b/internal/globals/globals.go
@@ -58,6 +58,8 @@ type GlobalOpts struct {
 	HomeDir string
 	// Out is where status messages are written. Defaults to os.Stdout
 	Out io.Writer
+	// The platform to target for the Envoy install.
+	Platform version.Platform
 }
 
 const (
@@ -65,11 +67,11 @@ const (
 	DefaultHomeDir = "${HOME}/.func-e"
 	// DefaultEnvoyVersionsURL is the default value for GlobalOpts.EnvoyVersionsURL
 	DefaultEnvoyVersionsURL = "https://archive.tetratelabs.io/envoy/envoy-versions.json"
+	// DefaultPlatform is the current platform of the host machine
+	DefaultPlatform = version.Platform(runtime.GOOS + "/" + runtime.GOARCH)
 )
 
 var (
 	// EnvoyVersionPattern is used to validate versions and is the same pattern as release-versions-schema.json.
 	EnvoyVersionPattern = regexp.MustCompile(`^[1-9][0-9]*\.[0-9]+\.[0-9]+(_debug)?$`)
-	// CurrentPlatform is the platform of the current process. This is used as a key in EnvoyVersion.Tarballs.
-	CurrentPlatform = version.Platform(runtime.GOOS + "/" + runtime.GOARCH)
 )


### PR DESCRIPTION
This PR adds a CLI flag for specifying a target platform for the Envoy install. This also includes the ability to specify a target platform through an environment variable.

Closes #299 