### PR TITLE
Simplifies version override so it is more like other packages

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -17,7 +17,7 @@ project_name: func-e
 builds:
   - binary: func-e
     # Updates the version so that `func-e -v` prints out the release version instead of "dev"
-    ldflags: "-s -w -X github.com/tetratelabs/func-e/internal/version.funcE={{.Version}}"
+    ldflags: "-s -w -X main.version={{.Version}}"
     main: .
     env:
       - CGO_ENABLED=0

--- a/internal/cmd/help_test.go
+++ b/internal/cmd/help_test.go
@@ -18,20 +18,18 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 
 	"github.com/tetratelabs/func-e/internal/globals"
-	"github.com/tetratelabs/func-e/internal/version"
 )
 
 func TestFuncEHelp(t *testing.T) {
 	for _, command := range []string{"", "use", "versions", "run"} {
 		command := command
 		t.Run(command, func(t *testing.T) {
-			c, stdout, _ := newApp(&globals.GlobalOpts{})
+			c, stdout, _ := newApp(&globals.GlobalOpts{Version: "1.0", EnvoyVersion: "1.99.0"})
 			args := []string{"func-e"}
 			if command != "" {
 				args = []string{"func-e", "help", command}
@@ -44,11 +42,8 @@ func TestFuncEHelp(t *testing.T) {
 			}
 
 			bytes, err := os.ReadFile(filepath.Join("testdata", expected))
-			want := strings.ReplaceAll(string(bytes), "{VERSION}", string(version.FuncE))
-			want = strings.ReplaceAll(want, "{ENVOY_VERSION}", string(version.LastKnownEnvoy))
-
 			require.NoError(t, err)
-			require.Equal(t, want, stdout.String())
+			require.Equal(t, string(bytes), stdout.String())
 		})
 	}
 }

--- a/internal/cmd/run.go
+++ b/internal/cmd/run.go
@@ -144,7 +144,7 @@ func setHomeEnvoyVersion(ctx context.Context, o *globals.GlobalOpts) error {
 
 	// First time install: look up the latest version, which may be newer than version.LastKnownEnvoy!
 	fmt.Fprintln(o.Out, "looking up latest version") //nolint
-	m, err := envoy.FuncEVersions(ctx, o.EnvoyVersionsURL, globals.CurrentPlatform, version.FuncE)
+	m, err := envoy.FuncEVersions(ctx, o.EnvoyVersionsURL, globals.CurrentPlatform, o.Version)
 	if err != nil {
 		return NewValidationError(`couldn't read latest version from %s: %s`, o.EnvoyVersionsURL, err)
 	}

--- a/internal/cmd/testdata/func-e_help.txt
+++ b/internal/cmd/testdata/func-e_help.txt
@@ -6,15 +6,15 @@ USAGE:
    downloads and installs the latest version of Envoy for you.
 
    To list versions of Envoy you can use, execute `func-e versions -a`. To
-   choose one, invoke `func-e use {ENVOY_VERSION}`. This installs into
-   `$FUNC_E_HOME/versions/{ENVOY_VERSION}`, if not already present.
+   choose one, invoke `func-e use 1.99.0`. This installs into
+   `$FUNC_E_HOME/versions/1.99.0`, if not already present.
 
    You may want to override `$ENVOY_VERSIONS_URL` to supply custom builds or
    otherwise control the source of Envoy binaries. When overriding, validate
    your JSON first: https://archive.tetratelabs.io/release-versions-schema.json
 
 VERSION:
-   {VERSION}
+   1.0
 
 COMMANDS:
    help      Shows how to use a [command]

--- a/internal/cmd/testdata/func-e_use_help.txt
+++ b/internal/cmd/testdata/func-e_use_help.txt
@@ -13,4 +13,4 @@ DESCRIPTION:
    depending on which is present.
    
    Example:
-   $ func-e use {ENVOY_VERSION}
+   $ func-e use 1.99.0

--- a/internal/cmd/use.go
+++ b/internal/cmd/use.go
@@ -26,6 +26,8 @@ import (
 
 // NewUseCmd create a command responsible for downloading and extracting Envoy
 func NewUseCmd(o *globals.GlobalOpts) *cli.Command {
+	lastKnownEnvoy := getLastKnownEnvoy(o)
+
 	return &cli.Command{
 		Name:      "use",
 		Usage:     `Sets the current [version] used by the "run" command`,
@@ -38,7 +40,7 @@ This updates %s or %s with [version],
 depending on which is present.
 
 Example:
-$ func-e use %s`, envoy.CurrentVersionWorkingDirFile, envoy.CurrentVersionHomeDirFile, version.LastKnownEnvoy),
+$ func-e use %s`, envoy.CurrentVersionWorkingDirFile, envoy.CurrentVersionHomeDirFile, lastKnownEnvoy),
 		Before: validateVersionArg,
 		Action: func(c *cli.Context) error {
 			v := version.Version(c.Args().First())

--- a/internal/cmd/versions.go
+++ b/internal/cmd/versions.go
@@ -50,7 +50,7 @@ func NewVersionsCmd(o *globals.GlobalOpts) *cli.Command {
 			currentVersion, currentVersionSource, _ := envoy.CurrentVersion(o.HomeDir)
 
 			if c.Bool("all") {
-				if ev, err := envoy.FuncEVersions(c.Context, o.EnvoyVersionsURL, globals.CurrentPlatform, version.FuncE); err != nil {
+				if ev, err := envoy.FuncEVersions(c.Context, o.EnvoyVersionsURL, globals.CurrentPlatform, o.Version); err != nil {
 					return err
 				} else if err := addAvailableVersions(&rows, ev.Versions, globals.CurrentPlatform); err != nil {
 					return err

--- a/internal/envoy/http_test.go
+++ b/internal/envoy/http_test.go
@@ -23,7 +23,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/tetratelabs/func-e/internal/globals"
-	"github.com/tetratelabs/func-e/internal/version"
 )
 
 func TestHttpGet_AddsDefaultHeaders(t *testing.T) {
@@ -34,7 +33,7 @@ func TestHttpGet_AddsDefaultHeaders(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	res, err := httpGet(context.Background(), ts.URL, globals.CurrentPlatform, version.FuncE)
+	res, err := httpGet(context.Background(), ts.URL, globals.CurrentPlatform, "dev")
 	require.NoError(t, err)
 
 	defer res.Body.Close()

--- a/internal/envoy/install_test.go
+++ b/internal/envoy/install_test.go
@@ -54,7 +54,7 @@ func TestUntarEnvoyError(t *testing.T) {
 
 	url := version.TarballURL(server.URL + "/file.tar.gz")
 	t.Run("error on incorrect URL", func(t *testing.T) {
-		err := untarEnvoy(ctx, dst, url, tarballSHA256sum, globals.CurrentPlatform, version.FuncE)
+		err := untarEnvoy(ctx, dst, url, tarballSHA256sum, globals.CurrentPlatform, "dev")
 		require.EqualError(t, err, fmt.Sprintf(`received 404 status code from %s`, url))
 	})
 
@@ -62,7 +62,7 @@ func TestUntarEnvoyError(t *testing.T) {
 		w.WriteHeader(200)
 	}
 	t.Run("error on empty", func(t *testing.T) {
-		err := untarEnvoy(ctx, dst, url, tarballSHA256sum, globals.CurrentPlatform, version.FuncE)
+		err := untarEnvoy(ctx, dst, url, tarballSHA256sum, globals.CurrentPlatform, "dev")
 		require.EqualError(t, err, fmt.Sprintf(`error untarring %s: EOF`, url))
 	})
 
@@ -71,7 +71,7 @@ func TestUntarEnvoyError(t *testing.T) {
 		w.Write([]byte("mary had a little lamb")) //nolint
 	}
 	t.Run("error on not a tar", func(t *testing.T) {
-		err := untarEnvoy(ctx, dst, url, tarballSHA256sum, globals.CurrentPlatform, version.FuncE)
+		err := untarEnvoy(ctx, dst, url, tarballSHA256sum, globals.CurrentPlatform, "dev")
 		require.EqualError(t, err, fmt.Sprintf(`error untarring %s: gzip: invalid header`, url))
 	})
 
@@ -80,7 +80,7 @@ func TestUntarEnvoyError(t *testing.T) {
 		w.Write(tarball) //nolint
 	}
 	t.Run("error on wrong sha256sum a tar", func(t *testing.T) {
-		err := untarEnvoy(ctx, dst, url, "cafebabe", globals.CurrentPlatform, version.FuncE)
+		err := untarEnvoy(ctx, dst, url, "cafebabe", globals.CurrentPlatform, "dev")
 		require.EqualError(t, err, fmt.Sprintf(`expected SHA-256 sum "cafebabe", but have "%s" from %s`, tarballSHA256sum, url))
 	})
 }
@@ -99,7 +99,7 @@ func TestUntarEnvoy(t *testing.T) {
 	}))
 	defer server.Close()
 
-	err := untarEnvoy(context.Background(), tempDir, version.TarballURL(server.URL), tarballSHA256sum, globals.CurrentPlatform, version.FuncE)
+	err := untarEnvoy(context.Background(), tempDir, version.TarballURL(server.URL), tarballSHA256sum, globals.CurrentPlatform, "dev")
 	require.NoError(t, err)
 	require.FileExists(t, filepath.Join(tempDir, binEnvoy))
 }

--- a/internal/globals/globals.go
+++ b/internal/globals/globals.go
@@ -46,6 +46,9 @@ type RunOpts struct {
 type GlobalOpts struct {
 	// RunOpts are inlined to allow tests to override parameters without changing ENV variables or flags
 	RunOpts
+	// Version is the version of the CLI, used in help statements and HTTP requests via "User-Agent".
+	// Override this via "-X main.version=XXX"
+	Version version.Version
 	// EnvoyVersionsURL is the path to the envoy-versions.json. Defaults to DefaultEnvoyVersionsURL
 	EnvoyVersionsURL string
 	// EnvoyVersion is the default version of Envoy to run. Defaults to the contents of "$HomeDir/versions/version".

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -17,12 +17,6 @@ package version
 
 import _ "embed" // We embed the Envoy version so that we can cache it in CI
 
-var funcE = "dev"
-
-// FuncE is the version of the CLI, used in help statements and HTTP requests via "User-Agent".
-// Override this via "-X github.com/tetratelabs/func-e/internal/version.funcE=XXX"
-var FuncE = Version(funcE)
-
 //go:embed last_known_envoy.txt
 var lastKnownEnvoy string
 

--- a/main.go
+++ b/main.go
@@ -23,15 +23,19 @@ import (
 
 	cmdutil "github.com/tetratelabs/func-e/internal/cmd"
 	"github.com/tetratelabs/func-e/internal/globals"
+	versionutil "github.com/tetratelabs/func-e/internal/version"
 )
 
 func main() {
 	os.Exit(run(os.Stdout, os.Stderr, os.Args))
 }
 
+// version is the string representation of globals.GlobalOpts
+var version = "dev"
+
 // run handles all error logging and coding so that no other place needs to.
 func run(stdout, stderr io.Writer, args []string) int {
-	app := cmdutil.NewApp(&globals.GlobalOpts{Out: stdout})
+	app := cmdutil.NewApp(&globals.GlobalOpts{Version: versionutil.Version(version), Out: stdout})
 	app.Writer = stdout
 	app.ErrWriter = stderr
 	app.Action = func(c *cli.Context) error {


### PR DESCRIPTION
This makes the main version more normal. Ex.
```bash
$ go build -ldflags "-s -w -X main.version=foo" .

$ ./func-e -v
func-e version foo
```

This also gets rid of some shell games in static text tests.

Signed-off-by: Adrian Cole <adrian@tetrate.io>