### PR TITLE
Refactors SHA-256 code to isolate problem on Windows

### DIFF
--- a/internal/envoy/install_test.go
+++ b/internal/envoy/install_test.go
@@ -81,7 +81,7 @@ func TestUntarEnvoyError(t *testing.T) {
 	}
 	t.Run("error on wrong sha256sum a tar", func(t *testing.T) {
 		err := untarEnvoy(ctx, dst, url, "cafebabe", globals.DefaultPlatform, "dev")
-		require.EqualError(t, err, fmt.Sprintf(`expected SHA-256 sum "cafebabe", but have "%s" from %s`, tarballSHA256sum, url))
+		require.EqualError(t, err, fmt.Sprintf(`error untarring %s: expected SHA-256 sum "cafebabe", but have "%s"`, url, tarballSHA256sum))
 	})
 }
 

--- a/internal/tar/tar.go
+++ b/internal/tar/tar.go
@@ -34,6 +34,8 @@ import (
 	"github.com/tetratelabs/func-e/internal/version"
 )
 
+const pathSeparator = string(os.PathSeparator)
+
 type digester struct {
 	r io.Reader
 	h hash.Hash
@@ -87,7 +89,7 @@ func Untar(dst string, src io.Reader) error { // dst, src order like io.Copy
 		}
 
 		srcPath := filepath.Clean(header.Name)
-		slash := strings.Index(srcPath, "/")
+		slash := strings.Index(srcPath, pathSeparator)
 		if slash == -1 { // strip leading path
 			continue
 		}
@@ -185,7 +187,7 @@ func TarGz(dst, src string) error { //nolint dst, src order like io.Copy
 		if info.IsDir() {
 			return nil // nothing to write
 		}
-		if err := copy(tw, srcFS, header.Name, header.Size); err != nil {
+		if err := cp(tw, srcFS, header.Name, header.Size); err != nil {
 			return err
 		}
 		return tw.Flush()
@@ -193,7 +195,7 @@ func TarGz(dst, src string) error { //nolint dst, src order like io.Copy
 }
 
 // Copy the contents of the file into the tar without buffering
-func copy(dst io.Writer, src fs.FS, path string, n int64) error { // dst, src order like io.Copy
+func cp(dst io.Writer, src fs.FS, path string, n int64) error { // dst, src order like io.Copy
 	f, err := src.Open(path) //nolint:gosec
 	if err != nil {
 		return err

--- a/internal/tar/tar.go
+++ b/internal/tar/tar.go
@@ -52,7 +52,7 @@ func UntarAndVerify(dst string, src io.Reader, sha256Sum version.SHA256Sum) erro
 	if err := Untar(dst, &d); err != nil {
 		return err
 	}
-	sum := version.SHA256Sum(fmt.Sprintf("%x", d.h.Sum(nil)))
+	sum := version.SHA256Sum(hex.EncodeToString(d.h.Sum(nil)))
 	if sum != sha256Sum {
 		return fmt.Errorf("expected SHA-256 sum %q, but have %q", sha256Sum, sum)
 	}

--- a/internal/tar/tar.go
+++ b/internal/tar/tar.go
@@ -20,6 +20,7 @@ import (
 	"bufio"
 	"compress/gzip"
 	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 	"hash"
 	"io"

--- a/internal/tar/tar_test.go
+++ b/internal/tar/tar_test.go
@@ -181,8 +181,8 @@ func TestUntarAndVerify_InvalidSignature(t *testing.T) {
 	require.NoError(t, err)
 	defer f.Close()
 
-	err = UntarAndVerify(tempDir, f, "1234")
-	require.EqualError(t, err, `expected SHA-256 sum "1234", but have "0ff74a47ceef95ffaf6e629aac7e54d262300e5ee318830b41da1f809fc71afd"`)
+	err = UntarAndVerify(tempDir, f, "cafebabe")
+	require.EqualError(t, err, `expected SHA-256 sum "cafebabe", but have "0ff74a47ceef95ffaf6e629aac7e54d262300e5ee318830b41da1f809fc71afd"`)
 }
 
 // requireTestFiles ensures the given directory includes the testdata/foo directory

--- a/internal/tar/tar_test.go
+++ b/internal/tar/tar_test.go
@@ -16,6 +16,7 @@ package tar
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -27,6 +28,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/tetratelabs/func-e/internal/test/morerequire"
+	"github.com/tetratelabs/func-e/internal/version"
 )
 
 func TestNewDecompressor_Validates(t *testing.T) {
@@ -128,6 +130,59 @@ func TestUntar(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestUntarAndVerify ensures SHA-256 are valid regardless of platform running these tests.
+func TestUntarAndVerify(t *testing.T) {
+	for k, v := range map[string]version.SHA256Sum{
+		"testdata/empty.tar.xz": version.SHA256Sum("0ff74a47ceef95ffaf6e629aac7e54d262300e5ee318830b41da1f809fc71afd"),
+		"testdata/empty.tar.gz": version.SHA256Sum("0d4b6fdb100ea7581e94fbfb5d69ad42c902db6c12c4d16c298576df209c4d1e"),
+		"testdata/test.tar.xz":  version.SHA256Sum("65a3a72fcd6455e464e8f2196b7594eef73f7574b57b0cc88baa96be61ca74e4"),
+		"testdata/test.tar.gz":  version.SHA256Sum("e3d54b02088eb7e485c43120916644c485627c7336adee945f39be67533e1a75"),
+	} {
+		file := k
+		sha256 := v
+		t.Run(file, func(t *testing.T) {
+			tempDir, removeTempDir := morerequire.RequireNewTempDir(t)
+			defer removeTempDir()
+
+			f, err := os.Open(file)
+			require.NoError(t, err)
+			defer f.Close()
+
+			err = UntarAndVerify(tempDir, f, sha256)
+			require.NoError(t, err)
+		})
+	}
+}
+
+type errorReader struct {
+	err error
+}
+
+func (r errorReader) Read(_ []byte) (n int, err error) {
+	return 0, r.err
+}
+
+func TestUntarAndVerify_ErrorReading(t *testing.T) {
+	tempDir, removeTempDir := morerequire.RequireNewTempDir(t)
+	defer removeTempDir()
+
+	expectedErr := errors.New("ice cream")
+	err := UntarAndVerify(tempDir, &errorReader{expectedErr}, "1234")
+	require.Same(t, err, expectedErr)
+}
+
+func TestUntarAndVerify_InvalidSignature(t *testing.T) {
+	tempDir, removeTempDir := morerequire.RequireNewTempDir(t)
+	defer removeTempDir()
+
+	f, err := os.Open("testdata/empty.tar.xz")
+	require.NoError(t, err)
+	defer f.Close()
+
+	err = UntarAndVerify(tempDir, f, "1234")
+	require.EqualError(t, err, `expected SHA-256 sum "1234", but have "0ff74a47ceef95ffaf6e629aac7e54d262300e5ee318830b41da1f809fc71afd"`)
 }
 
 // requireTestFiles ensures the given directory includes the testdata/foo directory


### PR DESCRIPTION
It is currently difficult to tell if tar is related to the SHA-256
mismatch on windows, but not Linux. Better tests make it easier to
figure out and fix.
