### PR TITLE
Makes stdout.log and stderr.log close explicit

### DIFF
--- a/internal/cmd/run.go
+++ b/internal/cmd/run.go
@@ -81,6 +81,7 @@ state. On exit, these archive into ` + "`$FUNC_E_HOME/runs/$epochtime.tar.gz`",
 				return fmt.Errorf("couldn't create stdout log file: %w", err)
 			}
 			defer stdoutLog.Close() //nolint
+			r.OutFile = stdoutLog
 			r.Out = io.MultiWriter(c.App.Writer, stdoutLog)
 
 			stderrLog, err := os.OpenFile(filepath.Join(r.GetRunDir(), "stderr.log"), os.O_CREATE|os.O_WRONLY, 0600)
@@ -88,13 +89,8 @@ state. On exit, these archive into ` + "`$FUNC_E_HOME/runs/$epochtime.tar.gz`",
 				return fmt.Errorf("couldn't create stderr log file: %w", err)
 			}
 			defer stderrLog.Close() //nolint
+			r.ErrFile = stderrLog
 			r.Err = io.MultiWriter(c.App.ErrWriter, stderrLog)
-
-			// Ensure console redirect files close before we attempt to archive them
-			r.RegisterShutdownHook(func(ctx context.Context) error {
-				stdoutLog.Close() // nolint
-				return stderrLog.Close()
-			})
 
 			for _, enableShutdownHook := range shutdown.EnableHooks {
 				if err := enableShutdownHook(r); err != nil {

--- a/internal/envoy/runtime.go
+++ b/internal/envoy/runtime.go
@@ -44,9 +44,9 @@ func NewRuntime(opts *globals.RunOpts) *Runtime {
 type Runtime struct {
 	opts *globals.RunOpts
 
-	cmd *exec.Cmd
-	Out io.Writer
-	Err io.Writer
+	cmd              *exec.Cmd
+	Out, Err         io.Writer
+	OutFile, ErrFile *os.File
 
 	adminAddress, adminAddressPath, pidPath string
 

--- a/internal/envoy/shutdown.go
+++ b/internal/envoy/shutdown.go
@@ -65,6 +65,7 @@ func (r *Runtime) interruptEnvoy() {
 }
 
 func (r *Runtime) archiveRunDir() error {
+	// Ensure logs are closed before we try to archive them, particularly important in Windows.
 	if r.OutFile != nil {
 		r.OutFile.Close() //nolint
 	}

--- a/internal/envoy/shutdown.go
+++ b/internal/envoy/shutdown.go
@@ -65,6 +65,12 @@ func (r *Runtime) interruptEnvoy() {
 }
 
 func (r *Runtime) archiveRunDir() error {
+	if r.OutFile != nil {
+		r.OutFile.Close() //nolint
+	}
+	if r.ErrFile != nil {
+		r.ErrFile.Close() //nolint
+	}
 	if r.opts.DontArchiveRunDir {
 		return nil
 	}


### PR DESCRIPTION
This moves the logic that closes the stdout and stderr log to a place
where it can be closed explicitly before archive. Before, some paths
wouldn't close them, for example `func-e run --version` or anything else that didn't result in a listening process.
