### PR TITLE
Completes Windows EOL handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 
 # possible when testing .github/untar_func-e_release.sh
 func-e
+func-e.exe
 
 # Local Netlify folder
 .netlify

--- a/internal/cmd/app.go
+++ b/internal/cmd/app.go
@@ -23,6 +23,7 @@ import (
 	"github.com/urfave/cli/v2"
 
 	"github.com/tetratelabs/func-e/internal/globals"
+	"github.com/tetratelabs/func-e/internal/moreos"
 	"github.com/tetratelabs/func-e/internal/version"
 )
 
@@ -38,7 +39,7 @@ func NewApp(o *globals.GlobalOpts) *cli.App {
 	app.Usage = `Install and run Envoy`
 	// Keep lines at 77 to address leading indent of 3 in help statements
 	// NOTE: remove indenting ourselves after the first line after urfave/cli#1275.
-	app.UsageText = `To run Envoy, execute ` + "`func-e run -c your_envoy_config.yaml`" + `. This
+	app.UsageText = moreos.Sprintf(`To run Envoy, execute ` + "`func-e run -c your_envoy_config.yaml`" + `. This
    downloads and installs the latest version of Envoy for you.
 
    To list versions of Envoy you can use, execute ` + "`func-e versions -a`" + `. To
@@ -51,7 +52,7 @@ func NewApp(o *globals.GlobalOpts) *cli.App {
 
    Advanced:
    ` + "`FUNC_E_PLATFORM`" + ` overrides the host OS and architecture of Envoy binaries.
-   This value must be constant within a ` + "`$FUNC_E_HOME`" + `.`
+   This value must be constant within a ` + "`$FUNC_E_HOME`" + `.`)
 	app.Version = string(o.Version)
 	app.Flags = []cli.Flag{
 		&cli.StringFlag{
@@ -85,6 +86,8 @@ func NewApp(o *globals.GlobalOpts) *cli.App {
 	}
 
 	app.HideHelp = true
+	app.CustomAppHelpTemplate = moreos.Sprintf(cli.AppHelpTemplate)
+	cli.VersionPrinter = printVersion
 	app.Commands = []*cli.Command{
 		helpCommand,
 		NewRunCmd(o),
@@ -161,4 +164,8 @@ func setHomeDir(o *globals.GlobalOpts, homeDir string) error {
 		o.HomeDir = abs
 	}
 	return nil
+}
+
+func printVersion(c *cli.Context) {
+	moreos.Fprintf(c.App.Writer, "%v version %v\n", c.App.Name, c.App.Version) //nolint
 }

--- a/internal/cmd/help_test.go
+++ b/internal/cmd/help_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/tetratelabs/func-e/internal/globals"
+	"github.com/tetratelabs/func-e/internal/moreos"
 )
 
 func TestFuncEHelp(t *testing.T) {
@@ -43,7 +44,7 @@ func TestFuncEHelp(t *testing.T) {
 
 			bytes, err := os.ReadFile(filepath.Join("testdata", expected))
 			require.NoError(t, err)
-			require.Equal(t, string(bytes), stdout.String())
+			require.Equal(t, moreos.Sprintf(string(bytes)), stdout.String())
 		})
 	}
 }

--- a/internal/cmd/run_test.go
+++ b/internal/cmd/run_test.go
@@ -34,8 +34,6 @@ import (
 	"github.com/tetratelabs/func-e/internal/version"
 )
 
-const ln = moreos.LineSeparator
-
 // Runner allows us to not introduce dependency cycles on envoy.Runtime
 type runner struct {
 	c *cli.App
@@ -62,7 +60,7 @@ func TestFuncERun(t *testing.T) {
 
 	require.NoError(t, err)
 	require.Empty(t, stdout)
-	require.Equal(t, fmt.Sprintf("initializing epoch 0%[1]sstarting main dispatch loop%[1]s", ln), stderr.String())
+	require.Equal(t, moreos.Sprintf("initializing epoch 0\nstarting main dispatch loop\n"), stderr.String())
 }
 
 func TestFuncERun_TeesConsoleToLogs(t *testing.T) {
@@ -97,7 +95,7 @@ func TestFuncERun_ReadsHomeVersionFile(t *testing.T) {
 	runWithoutConfig(t, c)
 
 	// No implicit lookup
-	require.NotContains(t, o.Out.(*bytes.Buffer).String(), "looking up latest version"+ln)
+	require.NotContains(t, o.Out.(*bytes.Buffer).String(), moreos.Sprintf("looking up latest version"))
 	require.Equal(t, version.LastKnownEnvoy, o.EnvoyVersion)
 }
 
@@ -114,7 +112,7 @@ func TestFuncERun_CreatesHomeVersionFile(t *testing.T) {
 	runWithoutConfig(t, c)
 
 	// We logged the implicit lookup
-	require.Contains(t, o.Out.(*bytes.Buffer).String(), "looking up latest version"+ln)
+	require.Contains(t, o.Out.(*bytes.Buffer).String(), moreos.Sprintf("looking up latest version"))
 	require.FileExists(t, filepath.Join(o.HomeDir, "version"))
 	require.Equal(t, version.LastKnownEnvoy, o.EnvoyVersion)
 }
@@ -169,6 +167,6 @@ func TestFuncERun_ErrsWhenVersionsServerDown(t *testing.T) {
 	c, _, _ := newApp(o)
 	err := c.Run([]string{"func-e", "run"})
 
-	require.Contains(t, o.Out.(*bytes.Buffer).String(), "looking up latest version"+ln)
+	require.Contains(t, o.Out.(*bytes.Buffer).String(), moreos.Sprintf("looking up latest version"))
 	require.Contains(t, err.Error(), fmt.Sprintf(`couldn't read latest version from %s`, o.EnvoyVersionsURL))
 }

--- a/internal/cmd/use.go
+++ b/internal/cmd/use.go
@@ -15,12 +15,11 @@
 package cmd
 
 import (
-	"fmt"
-
 	"github.com/urfave/cli/v2"
 
 	"github.com/tetratelabs/func-e/internal/envoy"
 	"github.com/tetratelabs/func-e/internal/globals"
+	"github.com/tetratelabs/func-e/internal/moreos"
 	"github.com/tetratelabs/func-e/internal/version"
 )
 
@@ -32,7 +31,7 @@ func NewUseCmd(o *globals.GlobalOpts) *cli.Command {
 		Name:      "use",
 		Usage:     `Sets the current [version] used by the "run" command`,
 		ArgsUsage: "[version]",
-		Description: fmt.Sprintf(`The '[version]' is from the "versions -a" command.
+		Description: moreos.Sprintf(`The '[version]' is from the "versions -a" command.
 The Envoy [version] installs on-demand into $FUNC_E_HOME/versions/[version]
 if needed.
 
@@ -49,6 +48,7 @@ $ func-e use %s`, envoy.CurrentVersionWorkingDirFile, envoy.CurrentVersionHomeDi
 			}
 			return envoy.WriteCurrentVersion(v, o.HomeDir)
 		},
+		CustomHelpTemplate: moreos.Sprintf(cli.CommandHelpTemplate),
 	}
 }
 

--- a/internal/cmd/versions.go
+++ b/internal/cmd/versions.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/tetratelabs/func-e/internal/envoy"
 	"github.com/tetratelabs/func-e/internal/globals"
+	"github.com/tetratelabs/func-e/internal/moreos"
 	"github.com/tetratelabs/func-e/internal/version"
 )
 
@@ -69,13 +70,14 @@ func NewVersionsCmd(o *globals.GlobalOpts) *cli.Command {
 			w := tabwriter.NewWriter(c.App.Writer, 0, 0, 1, ' ', tabwriter.AlignRight)
 			for _, vr := range rows { //nolint:gocritic
 				if vr.version == currentVersion {
-					fmt.Fprintf(w, "* %s %s (set by %s)\n", vr.version, vr.releaseDate, currentVersionSource) //nolint
+					moreos.Fprintf(w, "* %s %s (set by %s)\n", vr.version, vr.releaseDate, currentVersionSource) //nolint
 				} else {
-					fmt.Fprintf(w, "  %s %s\n", vr.version, vr.releaseDate) //nolint
+					moreos.Fprintf(w, "  %s %s\n", vr.version, vr.releaseDate) //nolint
 				}
 			}
 			return w.Flush()
 		},
+		CustomHelpTemplate: moreos.Sprintf(cli.CommandHelpTemplate),
 	}
 }
 

--- a/internal/cmd/versions_cmd_test.go
+++ b/internal/cmd/versions_cmd_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/tetratelabs/func-e/internal/globals"
+	"github.com/tetratelabs/func-e/internal/moreos"
 	"github.com/tetratelabs/func-e/internal/test/morerequire"
 	"github.com/tetratelabs/func-e/internal/version"
 )
@@ -48,10 +49,10 @@ func TestFuncEVersions_NoCurrentVersion(t *testing.T) {
 	err := c.Run([]string{"func-e", "versions"})
 
 	require.NoError(t, err)
-	require.Equal(t, `  1.2.2 2021-01-31
+	require.Equal(t, moreos.Sprintf(`  1.2.2 2021-01-31
   1.1.2 2021-01-31
   1.2.1 2021-01-30
-`, stdout.String())
+`), stdout.String())
 	require.Empty(t, stderr)
 }
 
@@ -66,10 +67,10 @@ func TestFuncEVersions_CurrentVersion(t *testing.T) {
 
 		c, stdout, _ := newApp(o)
 		require.NoError(t, c.Run([]string{"func-e", "versions"}))
-		require.Equal(t, `  1.2.2 2021-01-31
+		require.Equal(t, moreos.Sprintf(`  1.2.2 2021-01-31
   1.1.2 2021-01-31
   1.2.1 2021-01-30
-`, stdout.String())
+`), stdout.String())
 	})
 
 	t.Run("set by $FUNC_E_HOME/version", func(t *testing.T) {
@@ -77,10 +78,10 @@ func TestFuncEVersions_CurrentVersion(t *testing.T) {
 
 		c, stdout, _ := newApp(o)
 		require.NoError(t, c.Run([]string{"func-e", "versions"}))
-		require.Equal(t, `  1.2.2 2021-01-31
+		require.Equal(t, moreos.Sprintf(`  1.2.2 2021-01-31
 * 1.1.2 2021-01-31 (set by $FUNC_E_HOME/version)
   1.2.1 2021-01-30
-`, stdout.String())
+`), stdout.String())
 	})
 
 	t.Run("set by $PWD/.envoy-version", func(t *testing.T) {
@@ -102,10 +103,10 @@ func TestFuncEVersions_CurrentVersion(t *testing.T) {
 
 		c, stdout, _ := newApp(o)
 		require.NoError(t, c.Run([]string{"func-e", "versions"}))
-		require.Equal(t, `  1.2.2 2021-01-31
+		require.Equal(t, moreos.Sprintf(`  1.2.2 2021-01-31
   1.1.2 2021-01-31
 * 1.2.1 2021-01-30 (set by $ENVOY_VERSION)
-`, stdout.String())
+`), stdout.String())
 	})
 }
 
@@ -117,10 +118,10 @@ func TestFuncEVersions_Sorted(t *testing.T) {
 	err := c.Run([]string{"func-e", "versions"})
 
 	require.NoError(t, err)
-	require.Equal(t, `  1.2.2 2021-01-31
+	require.Equal(t, moreos.Sprintf(`  1.2.2 2021-01-31
   1.1.2 2021-01-31
 * 1.2.1 2021-01-30 (set by $FUNC_E_HOME/version)
-`, stdout.String())
+`), stdout.String())
 	require.Empty(t, stderr)
 }
 
@@ -132,7 +133,7 @@ func TestFuncEVersions_All_OnlyRemote(t *testing.T) {
 	err := c.Run([]string{"func-e", "versions", "-a"})
 
 	require.NoError(t, err)
-	require.Equal(t, fmt.Sprintf("  %s 2020-12-31\n", version.LastKnownEnvoy), stdout.String())
+	require.Equal(t, moreos.Sprintf("  %s 2020-12-31\n", version.LastKnownEnvoy), stdout.String())
 	require.Empty(t, stderr)
 }
 
@@ -145,7 +146,7 @@ func TestFuncEVersions_All_RemoteIsCurrent(t *testing.T) {
 	morerequire.RequireSetMtime(t, versionDir, "2020-12-31")
 	require.NoError(t, os.WriteFile(filepath.Join(o.HomeDir, "version"), []byte(version.LastKnownEnvoy), 0600))
 
-	expected := fmt.Sprintf("* %s 2020-12-31 (set by $FUNC_E_HOME/version)\n", version.LastKnownEnvoy)
+	expected := moreos.Sprintf("* %s 2020-12-31 (set by $FUNC_E_HOME/version)\n", version.LastKnownEnvoy)
 
 	c, stdout, stderr := newApp(o)
 	err := c.Run([]string{"func-e", "versions", "-a"})
@@ -163,11 +164,11 @@ func TestFuncEVersions_All_Mixed(t *testing.T) {
 	err := c.Run([]string{"func-e", "versions", "-a"})
 
 	require.NoError(t, err)
-	require.Equal(t, fmt.Sprintf(`  1.2.2 2021-01-31
+	require.Equal(t, moreos.Sprintf(fmt.Sprintf(`  1.2.2 2021-01-31
   1.1.2 2021-01-31
 * 1.2.1 2021-01-30 (set by $FUNC_E_HOME/version)
   %s 2020-12-31
-`, version.LastKnownEnvoy), stdout.String())
+`, version.LastKnownEnvoy)), stdout.String())
 	require.Empty(t, stderr)
 }
 

--- a/internal/envoy/install.go
+++ b/internal/envoy/install.go
@@ -63,7 +63,7 @@ func InstallIfNeeded(ctx context.Context, o *globals.GlobalOpts, v version.Versi
 			return "", fmt.Errorf("unable to create directory %q: %w", installPath, err)
 		}
 
-		fmt.Fprintln(o.Out, "downloading", tarballURL)                                            //nolint
+		moreos.Fprintf(o.Out, "downloading %s\n", tarballURL)                                     //nolint
 		if err = untarEnvoy(ctx, installPath, tarballURL, sha256Sum, o.Platform, v); err != nil { //nolint
 			return "", err
 		}
@@ -71,7 +71,7 @@ func InstallIfNeeded(ctx context.Context, o *globals.GlobalOpts, v version.Versi
 			return "", fmt.Errorf("unable to set date of directory %q: %w", installPath, err)
 		}
 	case err == nil:
-		fmt.Fprintln(o.Out, v, "is already downloaded") //nolint
+		moreos.Fprintf(o.Out, "%s is already downloaded\n", v) //nolint
 	default:
 		// TODO: figure out how to get a stat error that isn't file not exist so we can test this
 		return "", err

--- a/internal/envoy/install_test.go
+++ b/internal/envoy/install_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/tetratelabs/func-e/internal/globals"
+	"github.com/tetratelabs/func-e/internal/moreos"
 	"github.com/tetratelabs/func-e/internal/test"
 	"github.com/tetratelabs/func-e/internal/test/morerequire"
 	"github.com/tetratelabs/func-e/internal/version"
@@ -167,7 +168,7 @@ func TestInstallIfNeeded(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, f.ModTime().UTC().Format("2006-01-02"), string(test.FakeReleaseDate))
 
-	require.Equal(t, fmt.Sprintln("downloading", o.tarballURL), out.String())
+	require.Equal(t, moreos.Sprintf("downloading %s\n", o.tarballURL), out.String())
 }
 
 func TestInstallIfNeeded_NotFound(t *testing.T) {
@@ -199,7 +200,7 @@ func TestInstallIfNeeded_AlreadyExists(t *testing.T) {
 
 	envoyPath, e := InstallIfNeeded(o.ctx, &o.GlobalOpts, version.LastKnownEnvoy)
 	require.NoError(t, e)
-	require.Equal(t, fmt.Sprintln(version.LastKnownEnvoy, "is already downloaded"), out.String())
+	require.Equal(t, moreos.Sprintf("%s is already downloaded\n", version.LastKnownEnvoy), out.String())
 
 	newStat, e := os.Stat(envoyPath)
 	require.NoError(t, e)

--- a/internal/envoy/run.go
+++ b/internal/envoy/run.go
@@ -42,7 +42,7 @@ func (r *Runtime) Run(ctx context.Context, args []string) (err error) {
 	defer func() {
 		if cmd.ProcessState != nil && cmd.ProcessState.ExitCode() > 0 {
 			if err != nil {
-				fmt.Fprintln(r.Out, "warning:", err) //nolint
+				moreos.Fprintf(r.Out, "warning: %s\n", err) //nolint
 			}
 			err = fmt.Errorf("envoy exited with status: %d", cmd.ProcessState.ExitCode())
 		}
@@ -53,14 +53,14 @@ func (r *Runtime) Run(ctx context.Context, args []string) (err error) {
 	}
 
 	// Print the process line to the console for user knowledge and parsing convenience
-	fmt.Fprintln(r.Out, "starting:", strings.Join(r.cmd.Args, " ")) //nolint
+	moreos.Fprintf(r.Out, "starting: %s\n", strings.Join(r.cmd.Args, " ")) //nolint
 	if err := cmd.Start(); err != nil {
 		return fmt.Errorf("unable to start Envoy process: %w", err)
 	}
 
 	// Warn, but don't fail if we can't write the pid file for some reason
 	if err := os.WriteFile(r.pidPath, []byte(strconv.Itoa(cmd.Process.Pid)), 0600); err != nil {
-		fmt.Fprintln(r.Out, "warning:", err) //nolint
+		moreos.Fprintf(r.Out, "warning: %s\n", err) //nolint
 	}
 
 	waitCtx, waitCancel := context.WithCancel(ctx)
@@ -96,7 +96,7 @@ func awaitAdminAddress(sigCtx context.Context, r *Runtime) {
 	for i := 0; i < 10 && sigCtx.Err() == nil; i++ {
 		adminAddress, adminErr := r.GetAdminAddress()
 		if adminErr == nil {
-			fmt.Fprintln(r.Out, "discovered admin address:", adminAddress) //nolint
+			moreos.Fprintf(r.Out, "discovered admin address: %s\n", adminAddress) //nolint
 			return
 		}
 		time.Sleep(200 * time.Millisecond)

--- a/internal/envoy/run_test.go
+++ b/internal/envoy/run_test.go
@@ -34,8 +34,6 @@ import (
 	"github.com/tetratelabs/func-e/internal/test/morerequire"
 )
 
-const ln = moreos.LineSeparator
-
 func TestRuntime_Run(t *testing.T) {
 	tempDir, removeTempDir := morerequire.RequireNewTempDir(t)
 	defer removeTempDir()
@@ -59,8 +57,8 @@ func TestRuntime_Run(t *testing.T) {
 			name: "func-e Ctrl+C",
 			args: []string{"-c", "envoy.yaml"},
 			// Don't warn the user when they exited the process
-			expectedStdout:   fmt.Sprintln("starting:", fakeEnvoy, "-c", "envoy.yaml", adminFlag) + "GET /ready HTTP/1.1" + ln,
-			expectedStderr:   fmt.Sprintf("initializing epoch 0%[1]sstarting main dispatch loop%[1]scaught SIGINT%[1]sexiting%[1]s", ln),
+			expectedStdout:   moreos.Sprintf("starting: %s -c envoy.yaml %s\nGET /ready HTTP/1.1\n", fakeEnvoy, adminFlag),
+			expectedStderr:   moreos.Sprintf("initializing epoch 0\nstarting main dispatch loop\ncaught SIGINT\nexiting\n"),
 			wantShutdownHook: true,
 		},
 		// We don't test envoy dying from an external signal as it isn't reported back to the func-e process and
@@ -69,8 +67,8 @@ func TestRuntime_Run(t *testing.T) {
 			name:           "Envoy exited with error",
 			shutdown:       func() { time.Sleep(time.Millisecond * 100) },
 			args:           []string{}, // no config file!
-			expectedStdout: fmt.Sprintln("starting:", fakeEnvoy, adminFlag),
-			expectedStderr: fmt.Sprintf("initializing epoch 0%[1]sexiting%[1]sAt least one of --config-path or --config-yaml or Options::configProto() should be non-empty%[1]s", ln),
+			expectedStdout: moreos.Sprintf("starting: %s %s\n", fakeEnvoy, adminFlag),
+			expectedStderr: moreos.Sprintf("initializing epoch 0\nexiting\nAt least one of --config-path or --config-yaml or Options::configProto() should be non-empty\n"),
 			expectedErr:    "envoy exited with status: 1",
 		},
 	}

--- a/internal/envoy/shutdown.go
+++ b/internal/envoy/shutdown.go
@@ -39,7 +39,7 @@ func (r *Runtime) handleShutdown(ctx context.Context) {
 	timeout, cancel := context.WithDeadline(ctx, deadline)
 	defer cancel()
 
-	fmt.Fprintf(r.Out, "invoking shutdown hooks with deadline %s\n", deadline.Format(dateFormat)) //nolint
+	moreos.Fprintf(r.Out, "invoking shutdown hooks with deadline %s\n", deadline.Format(dateFormat)) //nolint
 
 	// Run each hook in parallel, logging each error
 	var wg sync.WaitGroup
@@ -49,7 +49,7 @@ func (r *Runtime) handleShutdown(ctx context.Context) {
 		go func() {
 			defer wg.Done()
 			if err := f(timeout); err != nil {
-				fmt.Fprintln(r.Out, "failed shutdown hook:", err) //nolint
+				moreos.Fprintf(r.Out, "failed shutdown hook: %s\n", err) //nolint
 			}
 		}()
 	}
@@ -58,9 +58,9 @@ func (r *Runtime) handleShutdown(ctx context.Context) {
 
 func (r *Runtime) interruptEnvoy() {
 	p := r.cmd.Process
-	fmt.Fprintf(r.Out, "sending interrupt to envoy (pid=%d)\n", p.Pid) //nolint
+	moreos.Fprintf(r.Out, "sending interrupt to envoy (pid=%d)\n", p.Pid) //nolint
 	if err := moreos.Interrupt(p); err != nil {
-		fmt.Fprintln(r.Out, "warning:", err) //nolint
+		moreos.Fprintf(r.Out, "warning: %s\n", err) //nolint
 	}
 }
 

--- a/internal/envoy/shutdown/node.go
+++ b/internal/envoy/shutdown/node.go
@@ -27,6 +27,7 @@ import (
 	"github.com/shirou/gopsutil/v3/process"
 
 	"github.com/tetratelabs/func-e/internal/envoy"
+	"github.com/tetratelabs/func-e/internal/moreos"
 )
 
 // enableNodeCollection is a preset option that registers collection of node level information for debugging
@@ -159,7 +160,7 @@ func parseProc(ctx context.Context, p *process.Process) (*proc, error) {
 func printProcessTable(out io.Writer, parsed []*proc) error {
 	// Now, start writing the process table
 	w := tabwriter.NewWriter(out, 0, 8, 5, ' ', 0)
-	if _, err := fmt.Fprintln(w, "PID\tUSERNAME\tSTATUS\tRSS\tVSZ\tMINFLT\tMAJFLT\tPCPU\tPMEM\tARGS"); err != nil {
+	if _, err := moreos.Fprintf(w, "PID\tUSERNAME\tSTATUS\tRSS\tVSZ\tMINFLT\tMAJFLT\tPCPU\tPMEM\tARGS\n"); err != nil {
 		return err
 	}
 
@@ -168,7 +169,7 @@ func printProcessTable(out io.Writer, parsed []*proc) error {
 		if len(p.status) > 0 {
 			status = p.status[0]
 		}
-		if _, err := fmt.Fprintf(w, "%v\t%v\t%v\t%v\t%v\t%v\t%v\t%.2f\t%.2f\t%v\n",
+		if _, err := moreos.Fprintf(w, "%v\t%v\t%v\t%v\t%v\t%v\t%v\t%.2f\t%.2f\t%v\n",
 			p.pid, p.username, status, p.rss, p.vms, p.minflt, p.majflt, p.pCPU, p.pMem, p.cmd); err != nil {
 			return err
 		}

--- a/internal/moreos/moreos.go
+++ b/internal/moreos/moreos.go
@@ -44,7 +44,7 @@ func Sprintf(format string, a ...interface{}) string {
 	return fmt.Sprintf(strings.ReplaceAll(format, "\n", "\r\n"), a...)
 }
 
-// Fprintf is like fmt.Fprintf, but handles EOL according runtime.GOOS. See Sprintf for behavioural notes.
+// Fprintf is like fmt.Fprintf, but handles EOL according runtime.GOOS. See Sprintf for notes.
 func Fprintf(w io.Writer, format string, a ...interface{}) (n int, err error) {
 	if runtime.GOOS != OSWindows {
 		return fmt.Fprintf(w, format, a...)

--- a/internal/moreos/moreos_test.go
+++ b/internal/moreos/moreos_test.go
@@ -54,7 +54,7 @@ func TestIsExecutable_Not(t *testing.T) {
 	require.False(t, isExecutable(f))
 }
 
-func TestRewriteEOL(t *testing.T) {
+func TestSprintf(t *testing.T) {
 	input := "foo\n\nbar\n"
 	if runtime.GOOS == OSWindows {
 		require.Equal(t, "foo\r\n\r\nbar\r\n", Sprintf(input))

--- a/internal/moreos/moreos_test.go
+++ b/internal/moreos/moreos_test.go
@@ -19,6 +19,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/shirou/gopsutil/v3/process"
@@ -53,12 +54,36 @@ func TestIsExecutable_Not(t *testing.T) {
 	require.False(t, isExecutable(f))
 }
 
-func TestLineSeparator(t *testing.T) {
+func TestRewriteEOL(t *testing.T) {
+	input := "foo\n\nbar\n"
+	if runtime.GOOS == OSWindows {
+		require.Equal(t, "foo\r\n\r\nbar\r\n", Sprintf(input))
+	} else {
+		require.Equal(t, input, Sprintf(input))
+	}
+}
+
+func TestFprintf(t *testing.T) {
+	template := "%s\n\n%s\n"
+	stdout := new(bytes.Buffer)
+	count, err := Fprintf(stdout, template, "foo", "bar")
+	require.NoError(t, err)
+
+	expected := "foo\n\nbar\n"
+	if runtime.GOOS == OSWindows {
+		expected = "foo\r\n\r\nbar\r\n"
+	}
+
+	require.Equal(t, expected, stdout.String())
+	require.Equal(t, len(expected), count)
+}
+
+func TestEOL(t *testing.T) {
 	stdout := new(bytes.Buffer)
 	cmd := exec.Command("echo", "cats")
 	cmd.Stdout = stdout
 	require.NoError(t, cmd.Run())
-	require.Equal(t, "cats"+ln, stdout.String())
+	require.Equal(t, "cats"+eol, stdout.String())
 }
 
 func TestProcessGroupAttr_Interrupt(t *testing.T) {

--- a/internal/moreos/moreos_test.go
+++ b/internal/moreos/moreos_test.go
@@ -78,12 +78,14 @@ func TestFprintf(t *testing.T) {
 	require.Equal(t, len(expected), count)
 }
 
-func TestEOL(t *testing.T) {
+// TestSprintf_IdiomaticPerOS is here to ensure that the EOL translation makes sense. For example, in UNIX, we expect
+// \n and windows \r\n. This uses a real command to prove the point.
+func TestSprintf_IdiomaticPerOS(t *testing.T) {
 	stdout := new(bytes.Buffer)
 	cmd := exec.Command("echo", "cats")
 	cmd.Stdout = stdout
 	require.NoError(t, cmd.Run())
-	require.Equal(t, "cats"+eol, stdout.String())
+	require.Equal(t, Sprintf("cats\n"), stdout.String())
 }
 
 func TestProcessGroupAttr_Interrupt(t *testing.T) {

--- a/internal/moreos/proc_darwin.go
+++ b/internal/moreos/proc_darwin.go
@@ -19,10 +19,7 @@ import (
 	"syscall"
 )
 
-const (
-	ln  = "\n"
-	exe = ""
-)
+const exe = ""
 
 func processGroupAttr() *syscall.SysProcAttr {
 	return &syscall.SysProcAttr{Setpgid: true}

--- a/internal/moreos/proc_linux.go
+++ b/internal/moreos/proc_linux.go
@@ -19,10 +19,7 @@ import (
 	"syscall"
 )
 
-const (
-	ln  = "\n"
-	exe = ""
-)
+const exe = ""
 
 func processGroupAttr() *syscall.SysProcAttr {
 	// Pdeathsig aims to ensure the process group is cleaned up even if this process dies

--- a/internal/test/envoy.go
+++ b/internal/test/envoy.go
@@ -30,6 +30,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/tetratelabs/func-e/internal/moreos"
 	"github.com/tetratelabs/func-e/internal/test/morerequire"
 )
 
@@ -59,7 +60,7 @@ func RequireRun(t *testing.T, shutdown func(), r Runner, stderr io.Reader, args 
 
 	select { // Await run completion
 	case <-time.After(10 * time.Second):
-		t.Fatal("Run never completed")
+		t.Fatalf("Run never completed: %v", stderr)
 	case <-ctx.Done():
 	}
 	return //nolint
@@ -101,10 +102,7 @@ func requireBuildFakeEnvoy(t *testing.T) []byte {
 }
 
 func requireGoBin(t *testing.T) string {
-	binName := "go"
-	if runtime.GOOS == "windows" {
-		binName += ".exe"
-	}
+	binName := "go" + moreos.Exe
 	goBin := filepath.Join(runtime.GOROOT(), "bin", binName)
 	if _, err := os.Stat(goBin); err == nil {
 		return goBin

--- a/internal/test/server.go
+++ b/internal/test/server.go
@@ -54,9 +54,9 @@ func RequireEnvoyVersionsTestServer(t *testing.T, v version.Version) *httptest.S
 		LatestVersion: v,
 		Versions: map[version.Version]version.Release{ // hard-code date so that tests don't drift
 			v: {ReleaseDate: FakeReleaseDate, Tarballs: map[version.Platform]version.TarballURL{
-				version.Platform("linux/" + runtime.GOARCH):   TarballURL(h.URL, "linux", runtime.GOARCH, v),
-				version.Platform("darwin/" + runtime.GOARCH):  TarballURL(h.URL, "darwin", runtime.GOARCH, v),
-				version.Platform("windows/" + runtime.GOARCH): TarballURL(h.URL, "windows", runtime.GOARCH, v),
+				version.Platform(moreos.OSLinux + "/" + runtime.GOARCH):   TarballURL(h.URL, moreos.OSLinux, runtime.GOARCH, v),
+				version.Platform(moreos.OSDarwin + "/" + runtime.GOARCH):  TarballURL(h.URL, moreos.OSDarwin, runtime.GOARCH, v),
+				version.Platform(moreos.OSWindows + "/" + runtime.GOARCH): TarballURL(h.URL, moreos.OSWindows, runtime.GOARCH, v),
 			}}},
 		SHA256Sums: map[version.Tarball]version.SHA256Sum{},
 	}

--- a/main.go
+++ b/main.go
@@ -15,7 +15,6 @@
 package main
 
 import (
-	"fmt"
 	"io"
 	"os"
 
@@ -23,6 +22,7 @@ import (
 
 	cmdutil "github.com/tetratelabs/func-e/internal/cmd"
 	"github.com/tetratelabs/func-e/internal/globals"
+	"github.com/tetratelabs/func-e/internal/moreos"
 	versionutil "github.com/tetratelabs/func-e/internal/version"
 )
 
@@ -50,10 +50,10 @@ func run(stdout, stderr io.Writer, args []string) int {
 	}
 	if err := app.Run(args); err != nil {
 		if _, ok := err.(*cmdutil.ValidationError); ok {
-			fmt.Fprintln(stderr, err) //nolint
+			moreos.Fprintf(stderr, "%s\n", err) //nolint
 			logUsageError(app.Name, stderr)
 		} else {
-			fmt.Fprintln(stderr, "error:", err) //nolint
+			moreos.Fprintf(stderr, "error: %s\n", err) //nolint
 		}
 		return 1
 	}
@@ -61,5 +61,5 @@ func run(stdout, stderr io.Writer, args []string) int {
 }
 
 func logUsageError(name string, stderr io.Writer) {
-	fmt.Fprintln(stderr, "show usage with:", name, "help") //nolint
+	moreos.Fprintf(stderr, "show usage with: %s help\n", name) //nolint
 }

--- a/main_test.go
+++ b/main_test.go
@@ -21,6 +21,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
+	"github.com/tetratelabs/func-e/internal/moreos"
 )
 
 func TestRunErrors(t *testing.T) {
@@ -84,8 +86,8 @@ show usage with: func-e help
 
 			status := run(stdout, stderr, test.args)
 			require.Equal(t, test.expectedStatus, status)
-			require.Equal(t, test.expectedStdout, stdout.String())
-			require.Equal(t, test.expectedStderr, stderr.String())
+			require.Equal(t, moreos.Sprintf(test.expectedStdout), stdout.String())
+			require.Equal(t, moreos.Sprintf(test.expectedStderr), stderr.String())
 		})
 	}
 }


### PR DESCRIPTION
This replaces `moreos.LineSeparator` with `moreos.Sprintf` and `Fprintf` in order to address all places where newlines need to change.

See https://github.com/golang/go/issues/28822