### PR TITLE
Refactors e2e to not rely on make

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -57,4 +57,4 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: "Run e2e tests using released `func-e` binary"
-        run: E2E_FUNC_E_BINARY=$PWD/func-e make e2e
+        run: go test -parallel 1 -v -failfast ./e2e

--- a/Makefile
+++ b/Makefile
@@ -47,17 +47,14 @@ test:
 	@echo "--- test ---"
 	@go test $(TEST_PACKAGES)
 
-# End-to-end (e2e) tests run against a compiled binary.
-#
-# When E2E_FUNC_E_PATH isn't set, the func-e binary is built on-demand.
+# End-to-end (e2e) tests run against the func-e binary, built on-demand with goreleaser.
 #
 # Tests run one at a time, in verbose mode, so that failures are easy to diagnose.
 # Note: -failfast helps as it stops at the first error. However, it is not a cacheable flag, so runs won't cache.
-E2E_FUNC_E_PATH ?= $(PWD)/$(BIN)
 .PHONY: e2e
-e2e: $(E2E_FUNC_E_PATH)
+e2e: $(BIN)
 	@echo "--- e2e ---"
-	@E2E_FUNC_E_PATH=$(E2E_FUNC_E_PATH) go test -parallel 1 -v -failfast ./e2e
+	@E2E_FUNC_E_PATH=$(PWD)/$(BIN) go test -parallel 1 -v -failfast ./e2e
 
 ##@ Code quality and integrity
 

--- a/Makefile
+++ b/Makefile
@@ -49,15 +49,15 @@ test:
 
 # End-to-end (e2e) tests run against a compiled binary.
 #
-# When E2E_FUNC_E_BINARY isn't set, the func-e binary is built on-demand.
+# When E2E_FUNC_E_PATH isn't set, the func-e binary is built on-demand.
 #
 # Tests run one at a time, in verbose mode, so that failures are easy to diagnose.
 # Note: -failfast helps as it stops at the first error. However, it is not a cacheable flag, so runs won't cache.
-E2E_FUNC_E_BINARY ?= $(BIN)
+E2E_FUNC_E_PATH ?= $(BIN)
 .PHONY: e2e
-e2e: $(E2E_FUNC_E_BINARY)
+e2e: $(E2E_FUNC_E_PATH)
 	@echo "--- e2e ---"
-	@go test -parallel 1 -v -failfast ./e2e
+	@E2E_FUNC_E_PATH=$(E2E_FUNC_E_PATH) go test -parallel 1 -v -failfast ./e2e
 
 ##@ Code quality and integrity
 

--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,7 @@ test:
 #
 # Tests run one at a time, in verbose mode, so that failures are easy to diagnose.
 # Note: -failfast helps as it stops at the first error. However, it is not a cacheable flag, so runs won't cache.
-E2E_FUNC_E_PATH ?= $(BIN)
+E2E_FUNC_E_PATH ?= $(PWD)/$(BIN)
 .PHONY: e2e
 e2e: $(E2E_FUNC_E_PATH)
 	@echo "--- e2e ---"

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -16,7 +16,7 @@ make e2e
 ```
 
 Tests look for `func-e` (or `func-e.exe` in Windows), in the current directory. When run via `make`, the binary location
-is read from `E2E_FUNC_E_PATH`: the `goreleaser` dist directory of the current platform. Ex. `dist/func-e_darwin_amd64`
+is read from `E2E_FUNC_E_PATH`: the `goreleaser` dist of the current platform. Ex. `$PWD/dist/func-e_darwin_amd64`
 
 If the `func-e` version is a snapshot and "envoy-versions.json" exists, tests run against the local. This allows local
 development and pull requests to verify changes not yet [published](https://archive.tetratelabs.io/envoy/envoy-versions.json)

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -4,20 +4,23 @@ This directory holds the end-to-end tests for `func-e`.
 
 By default, end-to-end (e2e) tests verify a `func-e` binary built from [main.go](../main.go)
 
-Ex. in native go commands:
+## Using native go commands:
+End-to-end tests default to look for `func-e` (or `func-e.exe` in Windows), in the project root (current directory).
+
 ```bash
 go build --ldflags '-s -w' .
 go test -parallel 1 -v -failfast ./e2e
 ```
 
-Ex. using `make`
+## Using `make`
+When run via `make`, `func-e` is built on-demand by `goreleaser` (implicitly `make bin`)
+Ex. `$PWD/dist/func-e_darwin_amd64/func-e`
+
 ```bash
 make e2e
 ```
 
-Tests look for `func-e` (or `func-e.exe` in Windows), in the current directory. When run via `make`, the binary location
-is read from `E2E_FUNC_E_PATH`: the `goreleaser` dist of the current platform. Ex. `$PWD/dist/func-e_darwin_amd64`
-
+## Envoy version list
 If the `func-e` version is a snapshot and "envoy-versions.json" exists, tests run against the local. This allows local
 development and pull requests to verify changes not yet [published](https://archive.tetratelabs.io/envoy/envoy-versions.json)
 or those that effect the [schema](https://archive.tetratelabs.io/release-versions-schema.json).

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -4,12 +4,19 @@ This directory holds the end-to-end tests for `func-e`.
 
 By default, end-to-end (e2e) tests verify a `func-e` binary built from [main.go](../main.go)
 
-Ex run this from the project root:
-```shell
+Ex. in native go commands:
+```bash
+go build --ldflags '-s -w' .
+go test -parallel 1 -v -failfast ./e2e
+```
+
+Ex. using `make`
+```bash
 make e2e
 ```
 
-You can override the binary tested by setting `E2E_FUNC_E_BINARY` to an alternative location, for example a release.
+Tests look for `func-e` (or `func-e.exe` in Windows), in the current directory. When run via `make`, the binary location
+is read from `E2E_FUNC_E_PATH`: the `goreleaser` dist directory of the current platform. Ex. `dist/func-e_darwin_amd64`
 
 If the `func-e` version is a snapshot and "envoy-versions.json" exists, tests run against the local. This allows local
 development and pull requests to verify changes not yet [published](https://archive.tetratelabs.io/envoy/envoy-versions.json)

--- a/e2e/main_test.go
+++ b/e2e/main_test.go
@@ -33,7 +33,7 @@ import (
 
 //nolint:golint
 const (
-	// funcEPathEnvKey holds the path to funcEBin (defaults to pwd)
+	// funcEPathEnvKey holds the path to funcEBin (defaults to the project root `../`)
 	funcEPathEnvKey        = "E2E_FUNC_E_PATH"
 	envoyVersionsURLEnvKey = "ENVOY_VERSIONS_URL"
 	envoyVersionsJSON      = "envoy-versions.json"

--- a/e2e/main_test.go
+++ b/e2e/main_test.go
@@ -105,7 +105,7 @@ func mockEnvoyVersionsServer() (*httptest.Server, error) {
 	return ts, nil
 }
 
-// readFuncEBin reads E2E_FUNC_E_PATH or defaults to "./func-e"
+// readFuncEBin reads E2E_FUNC_E_PATH or defaults to "../func-e"
 // An error is returned if the value isn't an executable file.
 func readFuncEBin() error {
 	path := os.Getenv(funcEPathEnvKey)


### PR DESCRIPTION
This refactors E2E tests to not rely on make. This gives us more flexibility in windows and also for how we download the release binary.