### PR TITLE
Adds Windows support

### DIFF
--- a/.bingo/Variables.mk
+++ b/.bingo/Variables.mk
@@ -2,7 +2,9 @@
 # All tools are designed to be build inside $GOBIN.
 BINGO_DIR := $(dir $(lastword $(MAKEFILE_LIST)))
 GOPATH ?= $(shell go env GOPATH)
-GOBIN  ?= $(firstword $(subst :, ,${GOPATH}))/bin
+# This handles translation for Windows, but only in cygwin or similar environments
+PATHSEP := $(if $(COMSPEC),;,:)
+GOBIN  ?= $(firstword $(subst $(PATHSEP), ,$(subst \,/,${GOPATH})))/bin
 GO     ?= $(shell which go)
 
 # Below generated variables ensure that every time a tool under each variable is invoked, the correct version

--- a/.github/workflows/commit.yaml
+++ b/.github/workflows/commit.yaml
@@ -82,3 +82,37 @@ jobs:
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         run: bash <(curl -s https://codecov.io/bash)
+
+  test-windows:
+    name: "Run unit tests (windows-latest)"
+    runs-on: windows-latest
+    timeout-minutes: 90  # instead of 360 by default
+    steps:
+      - name: "Checkout"
+        uses: actions/checkout@v2
+
+      - name: "Install Go"
+        uses: actions/setup-go@v2
+        with:
+          go-version: ${{ env.GO_VERSION }}
+
+      - name: "Cache dependencies"
+        uses: actions/cache@v2
+        with:
+          # This combines unrelated caches because actions/cache@v2 doesn't support multiple
+          # instances, rather a combined path. https://github.com/actions/cache/issues/16
+          path: |  # ~\.func-e\versions is cached so that we only re-download once: for TestFuncEInstall
+            ~\.func-e\versions
+            ~\go\pkg\mod
+          key: test-windows-latest-${{ env.GO_VERSION }}-go-${{ hashFiles('internal/version/last_known_envoy.txt', 'go.sum') }}
+          restore-keys: test-windows-latest-${{ env.GO_VERSION }}-go-
+
+      - name: "Run unit tests"
+        run: go test . ./internal/...
+
+      - name: "Build the `func-e` binary"
+        run: go build --ldflags '-s -w' .
+
+      - name: "Run e2e tests using the `func-e` binary"
+        run: go test -parallel 1 -v -failfast ./e2e
+

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -24,6 +24,7 @@ builds:
     goos:
       - linux
       - darwin
+      - windows
     goarch:
       - amd64
       - arm64

--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ site: $(HUGO)
 
 ##@ Unit and End-to-End tests
 
-TEST_PACKAGES ?= $(shell go list ./... | grep -v -e github.com/tetratelabs/func-e/e2e -e github.com/tetratelabs/func-e/site)
+TEST_PACKAGES ?= . ./internal/...
 .PHONY: test
 test:
 	@echo "--- test ---"

--- a/e2e/admin_test.go
+++ b/e2e/admin_test.go
@@ -76,9 +76,6 @@ func httpGet(ctx context.Context, url string) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	if err != nil {
-		return nil, err
-	}
 	defer resp.Body.Close() //nolint:errcheck
 	if resp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("unexpected status code: %d", resp.StatusCode)

--- a/e2e/func-e_run_test.go
+++ b/e2e/func-e_run_test.go
@@ -119,6 +119,7 @@ func envoyRunTest(t *testing.T, test func(context.Context, *funcE, *adminClient)
 				log.Printf("waiting for Envoy stdout to match %q after running [%v]", envoyStartedLine, c)
 			}
 		}
+		log.Printf("done stdout loop for func-e after running [%v]", c)
 	}()
 
 	go func() {
@@ -133,9 +134,11 @@ func envoyRunTest(t *testing.T, test func(context.Context, *funcE, *adminClient)
 				go runTestAndInterruptEnvoy(ctx, t, c, test) // don't block printing stderr!
 			}
 		}
+		log.Printf("done stderr loop for func-e after running [%v]", c)
 	}()
 
 	err = c.cmd.Wait() // This won't hang forever because newFuncE started it with a context timeout!
+	log.Printf("done waiting for func-e after running [%v]", c)
 	require.NoError(t, err)
 
 	// Ensure the Envoy process was terminated
@@ -150,7 +153,7 @@ func envoyRunTest(t *testing.T, test func(context.Context, *funcE, *adminClient)
 
 func runTestAndInterruptEnvoy(ctx context.Context, t *testing.T, c *funcE, test func(context.Context, *funcE, *adminClient)) {
 	defer func() {
-		log.Printf("shutting down Envoy after running [%v]", c)
+		log.Printf("interrupting func-e after running [%v]", c)
 		require.NoError(t, moreos.Interrupt(c.cmd.Process), "error shutting down Envoy after running [%v]", c)
 	}()
 	a := requireEnvoyReady(ctx, t, c)

--- a/e2e/func-e_test.go
+++ b/e2e/func-e_test.go
@@ -25,7 +25,7 @@ func TestFuncEVersion(t *testing.T) {
 
 	stdout, stderr, err := funcEExec("--version")
 
-	require.Regexp(t, `^func-e version ([^\s]+)\n$`, stdout)
+	require.Regexp(t, `^func-e version ([^\s]+)\r?\n$`, stdout)
 	require.Empty(t, stderr)
 	require.NoError(t, err)
 }

--- a/e2e/func-e_use_test.go
+++ b/e2e/func-e_use_test.go
@@ -15,7 +15,6 @@
 package e2e
 
 import (
-	"fmt"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -37,7 +36,7 @@ func TestFuncEUse(t *testing.T) {
 		stdout, stderr, err := funcEExec("--home-dir", homeDir, "use", string(version.LastKnownEnvoy))
 
 		require.NoError(t, err)
-		require.Regexp(t, `^downloading https:.*tar.*z\n$`, stdout)
+		require.Regexp(t, `^downloading https:.*tar.*z\r?\n$`, stdout)
 		require.Empty(t, stderr)
 
 		// The binary was installed
@@ -54,7 +53,7 @@ func TestFuncEUse(t *testing.T) {
 		stdout, stderr, err := funcEExec("--home-dir", homeDir, "use", string(version.LastKnownEnvoy))
 
 		require.NoError(t, err)
-		require.Equal(t, fmt.Sprintf("%s is already downloaded\n", version.LastKnownEnvoy), stdout)
+		require.Equal(t, moreos.Sprintf("%s is already downloaded\n", version.LastKnownEnvoy), stdout)
 		require.Empty(t, stderr)
 	})
 }
@@ -65,6 +64,6 @@ func TestFuncEUse_UnknownVersion(t *testing.T) {
 
 	require.EqualError(t, err, "exit status 1")
 	require.Empty(t, stdout)
-	require.Equal(t, fmt.Sprintf(`error: couldn't find version "%s" for platform "%s/%s"
+	require.Equal(t, moreos.Sprintf(`error: couldn't find version "%s" for platform "%s/%s"
 `, v, runtime.GOOS, runtime.GOARCH), stderr)
 }

--- a/e2e/func-e_versions_test.go
+++ b/e2e/func-e_versions_test.go
@@ -42,7 +42,7 @@ func TestFuncEVersions(t *testing.T) {
 
 	stdout, stderr, err := funcEExec("versions")
 
-	require.Regexp(t, fmt.Sprintf("[ *] %s 202[1-9]-[01][0-9]-[0-3][0-9].*\n", version.LastKnownEnvoy), stdout)
+	require.Regexp(t, fmt.Sprintf("[ *] %s 202[1-9]-[01][0-9]-[0-3][0-9].*\r?\n", version.LastKnownEnvoy), stdout)
 	require.Empty(t, stderr)
 	require.NoError(t, err)
 }
@@ -52,7 +52,7 @@ func TestFuncEVersions_All(t *testing.T) {
 
 	stdout, stderr, err := funcEExec("versions", "-a")
 
-	require.Regexp(t, fmt.Sprintf("[ *] %s 202[1-9]-[01][0-9]-[0-3][0-9].*\n", version.LastKnownEnvoy), stdout)
+	require.Regexp(t, fmt.Sprintf("[ *] %s 202[1-9]-[01][0-9]-[0-3][0-9].*\r?\n", version.LastKnownEnvoy), stdout)
 	require.Empty(t, stderr)
 	require.NoError(t, err)
 }

--- a/e2e/main_test.go
+++ b/e2e/main_test.go
@@ -61,7 +61,7 @@ func TestMain(m *testing.M) {
 	if _, err := os.Stat(envoyVersionsJSON); err == nil && strings.Contains(versionLine, "SNAPSHOT") {
 		s, err := mockEnvoyVersionsServer() // no defer s.Close() because os.Exit() subverts it
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "failed to serve %s: %v\n", envoyVersionsJSON, err)
+			moreos.Fprintf(os.Stderr, "failed to serve %s: %v\n", envoyVersionsJSON, err)
 			os.Exit(1)
 		}
 		os.Setenv(envoyVersionsURLEnvKey, s.URL)
@@ -70,7 +70,7 @@ func TestMain(m *testing.M) {
 }
 
 func exitOnInvalidBinary(err error) {
-	fmt.Fprintf(os.Stderr, `failed to start e2e tests due to an invalid "func-e" binary: %v\n`, err)
+	moreos.Fprintf(os.Stderr, `failed to start e2e tests due to an invalid "func-e" binary: %v\n`, err)
 	os.Exit(1)
 }
 
@@ -94,7 +94,7 @@ func mockEnvoyVersionsServer() (*httptest.Server, error) {
 			h := r.Header.Get(k)
 			if h != v {
 				w.WriteHeader(500)
-				w.Write([]byte(fmt.Sprintf("invalid %q: %s != %s\n", k, h, v))) //nolint
+				w.Write([]byte(moreos.Sprintf("invalid %q: %s != %s\n", k, h, v))) //nolint
 				return
 			}
 		}

--- a/internal/cmd/app_test.go
+++ b/internal/cmd/app_test.go
@@ -67,6 +67,9 @@ func TestHomeDir(t *testing.T) {
 	u, err := user.Current()
 	require.NoError(t, err)
 
+	alt1 := filepath.Join(u.HomeDir, "alt1")
+	alt2 := filepath.Join(u.HomeDir, "alt2")
+
 	tests := []testCase{ // we don't test default as that depends on the runtime env
 		{
 			name:     "default is ~/.func-e",
@@ -77,22 +80,22 @@ func TestHomeDir(t *testing.T) {
 			name: "FUNC_E_HOME env",
 			args: []string{"func-e"},
 			setup: func() func() {
-				return morerequire.RequireSetenv(t, "FUNC_E_HOME", "/from/FUNC_E_HOME/env")
+				return morerequire.RequireSetenv(t, "FUNC_E_HOME", alt1)
 			},
-			expected: "/from/FUNC_E_HOME/env",
+			expected: alt1,
 		},
 		{
 			name:     "--home-dir arg",
-			args:     []string{"func-e", "--home-dir", "/from/home-dir/arg"},
-			expected: "/from/home-dir/arg",
+			args:     []string{"func-e", "--home-dir", alt1},
+			expected: alt1,
 		},
 		{
 			name: "prioritizes --home-dir arg over FUNC_E_HOME env",
-			args: []string{"func-e", "--home-dir", "/from/home-dir/arg"},
+			args: []string{"func-e", "--home-dir", alt1},
 			setup: func() func() {
-				return morerequire.RequireSetenv(t, "FUNC_E_HOME", "/from/FUNC_E_HOME/env")
+				return morerequire.RequireSetenv(t, "FUNC_E_HOME", alt2)
 			},
-			expected: "/from/home-dir/arg",
+			expected: alt1,
 		},
 	}
 

--- a/internal/cmd/run.go
+++ b/internal/cmd/run.go
@@ -35,6 +35,7 @@ import (
 // NewRunCmd create a command responsible for starting an Envoy process
 func NewRunCmd(o *globals.GlobalOpts) *cli.Command {
 	var envoyVersion version.Version
+	runDirectoryExpression := moreos.ReplacePathSeparator("$FUNC_E_HOME/runs/$epochtime")
 	cmd := &cli.Command{
 		Name:            "run",
 		Usage:           "Run Envoy with the given [arguments...] until interrupted",
@@ -47,12 +48,12 @@ The first version in the below is run, controllable by the "use" command:
 The version to use is downloaded and installed, if necessary.
 
 Envoy interprets the '[arguments...]' and runs in the current working
-directory (aka $CWD) until func-e is interrupted (ex Ctrl+C, Ctrl+Break).
+directory (aka $PWD) until func-e is interrupted (ex Ctrl+C, Ctrl+Break).
 
 Envoy's process ID and console output write to "envoy.pid", stdout.log" and
-"stderr.log" in the run directory (` + "`$FUNC_E_HOME/runs/$epochtime`" + `).
+"stderr.log" in the run directory (` + fmt.Sprintf("`%s`", runDirectoryExpression) + `).
 When interrupted, shutdown hooks write files including network and process
-state. On exit, these archive into ` + "`$FUNC_E_HOME/runs/$epochtime.tar.gz`"),
+state. On exit, these archive into ` + fmt.Sprintf("`%s.tar.gz`", runDirectoryExpression)),
 		Before: func(c *cli.Context) error {
 			if err := os.MkdirAll(o.HomeDir, 0750); err != nil {
 				return NewValidationError(err.Error())

--- a/internal/cmd/run_test.go
+++ b/internal/cmd/run_test.go
@@ -134,7 +134,8 @@ func TestFuncERun_ValidatesHomeVersion(t *testing.T) {
 	err := c.Run([]string{"func-e", "run"})
 
 	// Verify the command failed with the expected error
-	require.EqualError(t, err, fmt.Sprintf(`invalid version in "$FUNC_E_HOME/version": "a.a.a" should look like "%s"`, version.LastKnownEnvoy))
+	expectedErr := fmt.Sprintf(`invalid version in "$FUNC_E_HOME/version": "a.a.a" should look like "%s"`, version.LastKnownEnvoy)
+	require.EqualError(t, err, moreos.ReplacePathSeparator(expectedErr))
 }
 
 // TestFuncERun_ValidatesWorkingVersion duplicates logic in version_test.go to ensure a non-home version validates.
@@ -152,7 +153,8 @@ func TestFuncERun_ValidatesWorkingVersion(t *testing.T) {
 	err := c.Run([]string{"func-e", "run"})
 
 	// Verify the command failed with the expected error
-	require.EqualError(t, err, fmt.Sprintf(`invalid version in "$PWD/.envoy-version": "b.b.b" should look like "%s"`, version.LastKnownEnvoy))
+	expectedErr := fmt.Sprintf(`invalid version in "$PWD/.envoy-version": "b.b.b" should look like "%s"`, version.LastKnownEnvoy)
+	require.EqualError(t, err, moreos.ReplacePathSeparator(expectedErr))
 }
 
 func TestFuncERun_ErrsWhenVersionsServerDown(t *testing.T) {

--- a/internal/cmd/testdata/func-e_run_help.txt
+++ b/internal/cmd/testdata/func-e_run_help.txt
@@ -14,7 +14,7 @@ DESCRIPTION:
    The version to use is downloaded and installed, if necessary.
    
    Envoy interprets the '[arguments...]' and runs in the current working
-   directory (aka $CWD) until func-e is interrupted (ex Ctrl+C, Ctrl+Break).
+   directory (aka $PWD) until func-e is interrupted (ex Ctrl+C, Ctrl+Break).
    
    Envoy's process ID and console output write to "envoy.pid", stdout.log" and
    "stderr.log" in the run directory (`$FUNC_E_HOME/runs/$epochtime`).

--- a/internal/cmd/usage_md_test.go
+++ b/internal/cmd/usage_md_test.go
@@ -16,6 +16,7 @@ package cmd
 
 import (
 	"os"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -23,12 +24,17 @@ import (
 	"github.com/urfave/cli/v2"
 
 	"github.com/tetratelabs/func-e/internal/globals"
+	"github.com/tetratelabs/func-e/internal/moreos"
 )
 
 const siteMarkdownFile = "../../USAGE.md"
 
 // TestUsageMarkdownMatchesCommands is in the "cmd" package because changes here will drift siteMarkdownFile.
 func TestUsageMarkdownMatchesCommands(t *testing.T) {
+	if runtime.GOOS == moreos.OSWindows {
+		t.SkipNow()
+	}
+
 	// Use a custom markdown template
 	old := cli.MarkdownDocTemplate
 	defer func() { cli.MarkdownDocTemplate = old }()

--- a/internal/cmd/use.go
+++ b/internal/cmd/use.go
@@ -26,20 +26,23 @@ import (
 // NewUseCmd create a command responsible for downloading and extracting Envoy
 func NewUseCmd(o *globals.GlobalOpts) *cli.Command {
 	lastKnownEnvoy := getLastKnownEnvoy(o)
+	versionsDir := moreos.ReplacePathSeparator("$FUNC_E_HOME/versions/")
+	currentVersionWorkingDirFile := moreos.ReplacePathSeparator(envoy.CurrentVersionWorkingDirFile)
+	currentVersionHomeDirFile := moreos.ReplacePathSeparator(envoy.CurrentVersionHomeDirFile)
 
 	return &cli.Command{
 		Name:      "use",
 		Usage:     `Sets the current [version] used by the "run" command`,
 		ArgsUsage: "[version]",
 		Description: moreos.Sprintf(`The '[version]' is from the "versions -a" command.
-The Envoy [version] installs on-demand into $FUNC_E_HOME/versions/[version]
+The Envoy [version] installs on-demand into `+versionsDir+`[version]
 if needed.
 
 This updates %s or %s with [version],
 depending on which is present.
 
 Example:
-$ func-e use %s`, envoy.CurrentVersionWorkingDirFile, envoy.CurrentVersionHomeDirFile, lastKnownEnvoy),
+$ func-e use %s`, currentVersionWorkingDirFile, currentVersionHomeDirFile, lastKnownEnvoy),
 		Before: validateVersionArg,
 		Action: func(c *cli.Context) error {
 			v := version.Version(c.Args().First())

--- a/internal/cmd/use_test.go
+++ b/internal/cmd/use_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/tetratelabs/func-e/internal/moreos"
 	"github.com/tetratelabs/func-e/internal/version"
 )
 
@@ -65,7 +66,7 @@ func TestFuncEUse_InstallsAndWritesHomeVersion(t *testing.T) {
 	require.NoError(t, c.Run([]string{"func-e", "use", string(o.EnvoyVersion)}))
 
 	// The binary was installed
-	require.FileExists(t, filepath.Join(o.HomeDir, "versions", string(o.EnvoyVersion), "bin", "envoy"))
+	require.FileExists(t, filepath.Join(o.HomeDir, "versions", string(o.EnvoyVersion), "bin", "envoy"+moreos.Exe))
 
 	// The current version was written
 	f, err := os.ReadFile(filepath.Join(o.HomeDir, "version"))

--- a/internal/cmd/versions_cmd_test.go
+++ b/internal/cmd/versions_cmd_test.go
@@ -91,10 +91,10 @@ func TestFuncEVersions_CurrentVersion(t *testing.T) {
 
 		c, stdout, _ := newApp(o)
 		require.NoError(t, c.Run([]string{"func-e", "versions"}))
-		require.Equal(t, `* 1.2.2 2021-01-31 (set by $PWD/.envoy-version)
+		require.Equal(t, moreos.Sprintf(`* 1.2.2 2021-01-31 (set by $PWD/.envoy-version)
   1.1.2 2021-01-31
   1.2.1 2021-01-30
-`, stdout.String())
+`), stdout.String())
 	})
 
 	t.Run("set by $ENVOY_VERSION", func(t *testing.T) {

--- a/internal/cmd/versions_test.go
+++ b/internal/cmd/versions_test.go
@@ -17,15 +17,21 @@ package cmd
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/tetratelabs/func-e/internal/moreos"
 	"github.com/tetratelabs/func-e/internal/test/morerequire"
 	"github.com/tetratelabs/func-e/internal/version"
 )
 
 func TestGetInstalledVersions_ErrorsWhenFileIsInVersionsDir(t *testing.T) {
+	if runtime.GOOS == moreos.OSWindows {
+		t.SkipNow() // golang/go#46734 wrong error on file where directory should be
+	}
+
 	homeDir, removeHomeDir := morerequire.RequireNewTempDir(t)
 	defer removeHomeDir()
 

--- a/internal/envoy/install_test.go
+++ b/internal/envoy/install_test.go
@@ -229,8 +229,11 @@ func TestVerifyEnvoy(t *testing.T) {
 		require.Nil(t, e)
 	})
 
+	require.NoError(t, os.Chmod(expectedEnvoyPath, 0600))
 	t.Run("envoy binary not executable", func(t *testing.T) {
-		require.NoError(t, os.Chmod(expectedEnvoyPath, 0600))
+		if runtime.GOOS == moreos.OSWindows {
+			t.Skip("execute bit isn't visible on windows")
+		}
 		EnvoyPath, e := verifyEnvoy(envoyPath)
 		require.Empty(t, EnvoyPath)
 		require.EqualError(t, e, fmt.Sprintf(`envoy binary not executable at %q`, expectedEnvoyPath))

--- a/internal/envoy/run_test.go
+++ b/internal/envoy/run_test.go
@@ -105,7 +105,7 @@ func TestRuntime_Run(t *testing.T) {
 
 			shutdown := tc.shutdown
 			if shutdown == nil {
-				shutdown = interrupt(r)
+				shutdown = ctrlC(r)
 			}
 
 			// tee the error stream so we can look for the "starting main dispatch loop" line without consuming it.
@@ -145,7 +145,7 @@ func TestRuntime_Run(t *testing.T) {
 	}
 }
 
-func interrupt(r *Runtime) func() {
+func ctrlC(r *Runtime) func() {
 	return func() {
 		fakeInterrupt := r.FakeInterrupt
 		if fakeInterrupt != nil {

--- a/internal/envoy/shutdown/admin_test.go
+++ b/internal/envoy/shutdown/admin_test.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/tetratelabs/func-e/internal/envoy"
 	"github.com/tetratelabs/func-e/internal/globals"
+	"github.com/tetratelabs/func-e/internal/moreos"
 	"github.com/tetratelabs/func-e/internal/test"
 	"github.com/tetratelabs/func-e/internal/test/morerequire"
 )
@@ -57,7 +58,7 @@ func TestEnableEnvoyAdminDataCollection(t *testing.T) {
 
 // runWithShutdownHook is like RequireRun, except invokes the hook on shutdown
 func runWithShutdownHook(t *testing.T, runDir string, hook func(r *envoy.Runtime) error, args ...string) error {
-	fakeEnvoy := filepath.Join(runDir, "envoy")
+	fakeEnvoy := filepath.Join(runDir, "envoy"+moreos.Exe)
 	test.RequireFakeEnvoy(t, fakeEnvoy)
 
 	o := &globals.RunOpts{EnvoyPath: fakeEnvoy, RunDir: runDir, DontArchiveRunDir: true}

--- a/internal/envoy/version.go
+++ b/internal/envoy/version.go
@@ -15,21 +15,21 @@
 package envoy
 
 import (
-	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
 
 	"github.com/tetratelabs/func-e/internal/globals"
+	"github.com/tetratelabs/func-e/internal/moreos"
 	"github.com/tetratelabs/func-e/internal/version"
 )
 
-var (
+const (
 	currentVersionVar = "$ENVOY_VERSION"
 	// CurrentVersionWorkingDirFile is used for stable "versions" and "help" output
-	CurrentVersionWorkingDirFile = filepath.Join("$PWD", ".envoy-version")
+	CurrentVersionWorkingDirFile = "$PWD/.envoy-version"
 	// CurrentVersionHomeDirFile is used for stable "versions" and "help" output
-	CurrentVersionHomeDirFile = filepath.Join("$FUNC_E_HOME", "version")
+	CurrentVersionHomeDirFile = "$FUNC_E_HOME/version"
 )
 
 // GetHomeVersion returns the default version in the "homeDir" and path to to it (homeVersionFile). When "v" is empty,
@@ -64,10 +64,10 @@ func CurrentVersion(homeDir string) (v version.Version, source string, err error
 
 func verifyVersion(v version.Version, source string, err error) error {
 	if err != nil {
-		return fmt.Errorf("couldn't read version from %s: %w", source, err)
+		return moreos.Errorf(`couldn't read version from %s: %w`, source, err)
 	}
 	if matched := globals.EnvoyVersionPattern.MatchString(string(v)); !matched {
-		return fmt.Errorf("invalid version in %q: %q should look like %q", source, v, version.LastKnownEnvoy)
+		return moreos.Errorf(`invalid version in %q: %q should look like %q`, source, v, version.LastKnownEnvoy)
 	}
 	return nil
 }
@@ -110,5 +110,7 @@ func getHomeVersion(homeDir string) (v version.Version, homeVersionFile string, 
 // VersionUsageList is the priority order of Envoy version sources.
 // This includes unresolved variables as it is both used statically for markdown generation, and also at runtime.
 func VersionUsageList() string {
-	return strings.Join([]string{currentVersionVar, CurrentVersionWorkingDirFile, CurrentVersionHomeDirFile}, ", ")
+	return moreos.ReplacePathSeparator(
+		strings.Join([]string{currentVersionVar, CurrentVersionWorkingDirFile, CurrentVersionHomeDirFile}, ", "),
+	)
 }

--- a/internal/envoy/version_test.go
+++ b/internal/envoy/version_test.go
@@ -22,12 +22,14 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/tetratelabs/func-e/internal/moreos"
 	"github.com/tetratelabs/func-e/internal/test/morerequire"
 	"github.com/tetratelabs/func-e/internal/version"
 )
 
 func TestVersionUsageList(t *testing.T) {
-	require.Equal(t, "$ENVOY_VERSION, $PWD/.envoy-version, $FUNC_E_HOME/version", VersionUsageList())
+	expected := moreos.ReplacePathSeparator("$ENVOY_VERSION, $PWD/.envoy-version, $FUNC_E_HOME/version")
+	require.Equal(t, expected, VersionUsageList())
 }
 
 func TestGetHomeVersion_Empty(t *testing.T) {
@@ -79,7 +81,8 @@ func TestGetHomeVersion_Validates(t *testing.T) {
 	require.NoError(t, os.WriteFile(homeVersionFile, []byte("a.a.a"), 0600))
 
 	_, _, err := GetHomeVersion(homeDir)
-	require.EqualError(t, err, fmt.Sprintf(`invalid version in "%s": "a.a.a" should look like "%s"`, CurrentVersionHomeDirFile, version.LastKnownEnvoy))
+	expectedErr := fmt.Sprintf(`invalid version in "%s": "a.a.a" should look like "%s"`, CurrentVersionHomeDirFile, version.LastKnownEnvoy)
+	require.EqualError(t, err, moreos.ReplacePathSeparator(expectedErr))
 }
 
 func TestWriteCurrentVersion_HomeDir(t *testing.T) {
@@ -172,7 +175,8 @@ func TestCurrentVersion_Validates(t *testing.T) {
 
 	t.Run("validates home version", func(t *testing.T) {
 		_, _, err := CurrentVersion(homeDir)
-		require.EqualError(t, err, fmt.Sprintf(`invalid version in "$FUNC_E_HOME/version": "a.a.a" should look like "%s"`, version.LastKnownEnvoy))
+		expectedErr := fmt.Sprintf(`invalid version in "$FUNC_E_HOME/version": "a.a.a" should look like "%s"`, version.LastKnownEnvoy)
+		require.EqualError(t, err, moreos.ReplacePathSeparator(expectedErr))
 	})
 
 	revertTempWd := morerequire.RequireChdirIntoTemp(t)
@@ -181,7 +185,8 @@ func TestCurrentVersion_Validates(t *testing.T) {
 
 	t.Run("validates $PWD/.envoy-version", func(t *testing.T) {
 		_, _, err := CurrentVersion(homeDir)
-		require.EqualError(t, err, fmt.Sprintf(`invalid version in "$PWD/.envoy-version": "b.b.b" should look like "%s"`, version.LastKnownEnvoy))
+		expectedErr := fmt.Sprintf(`invalid version in "$PWD/.envoy-version": "b.b.b" should look like "%s"`, version.LastKnownEnvoy)
+		require.EqualError(t, err, moreos.ReplacePathSeparator(expectedErr))
 	})
 
 	require.NoError(t, os.Remove(".envoy-version"))
@@ -189,7 +194,8 @@ func TestCurrentVersion_Validates(t *testing.T) {
 
 	t.Run("shows error reading $PWD/.envoy-version", func(t *testing.T) {
 		_, _, err := CurrentVersion(homeDir)
-		require.Contains(t, err.Error(), "couldn't read version from $PWD/.envoy-version")
+		expectedErr := moreos.ReplacePathSeparator("couldn't read version from $PWD/.envoy-version")
+		require.Contains(t, err.Error(), expectedErr)
 	})
 
 	revert := morerequire.RequireSetenv(t, "ENVOY_VERSION", "c.c.c")

--- a/internal/globals/globals.go
+++ b/internal/globals/globals.go
@@ -19,6 +19,7 @@ import (
 	"regexp"
 	"runtime"
 
+	"github.com/tetratelabs/func-e/internal/moreos"
 	"github.com/tetratelabs/func-e/internal/version"
 )
 
@@ -63,15 +64,17 @@ type GlobalOpts struct {
 }
 
 const (
-	// DefaultHomeDir is the default value for GlobalOpts.HomeDir
-	DefaultHomeDir = "${HOME}/.func-e"
 	// DefaultEnvoyVersionsURL is the default value for GlobalOpts.EnvoyVersionsURL
 	DefaultEnvoyVersionsURL = "https://archive.tetratelabs.io/envoy/envoy-versions.json"
+	// DefaultEnvoyVersionsSchemaURL is the JSON schema used to validate GlobalOpts.EnvoyVersionsURL
+	DefaultEnvoyVersionsSchemaURL = "https://archive.tetratelabs.io/release-versions-schema.json"
 	// DefaultPlatform is the current platform of the host machine
 	DefaultPlatform = version.Platform(runtime.GOOS + "/" + runtime.GOARCH)
 )
 
 var (
+	// DefaultHomeDir is the default value for GlobalOpts.HomeDir
+	DefaultHomeDir = moreos.ReplacePathSeparator("${HOME}/.func-e")
 	// EnvoyVersionPattern is used to validate versions and is the same pattern as release-versions-schema.json.
 	EnvoyVersionPattern = regexp.MustCompile(`^[1-9][0-9]*\.[0-9]+\.[0-9]+(_debug)?$`)
 )

--- a/internal/moreos/proc_windows.go
+++ b/internal/moreos/proc_windows.go
@@ -1,0 +1,91 @@
+// Copyright 2021 Tetrate
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package moreos
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+	"syscall"
+)
+
+const (
+	exe = ".exe"
+	// from WinError.h, but not defined for some reason in types_windows.go
+	errorInvalidParameter = 87
+)
+
+func processGroupAttr() *syscall.SysProcAttr {
+	return &syscall.SysProcAttr{
+		CreationFlags: syscall.CREATE_NEW_PROCESS_GROUP, // Stop Ctrl-Break propagation to allow shutdown-hooks
+	}
+}
+
+// interrupt contains signal_windows_test.go sendCtrlBreak() as there's no main source with the same.
+func interrupt(p *os.Process) error {
+	pid := p.Pid
+	d, err := syscall.LoadDLL("kernel32.dll")
+	if err != nil {
+		return errorInterrupting(pid, err)
+	}
+	proc, err := d.FindProc("GenerateConsoleCtrlEvent")
+	if err != nil {
+		return errorInterrupting(pid, err)
+	}
+	r, _, err := proc.Call(syscall.CTRL_BREAK_EVENT, uintptr(pid))
+	if r == 0 { // because err != nil on success "The operation completed successfully"
+		return errorInterrupting(pid, err)
+	}
+	return nil
+}
+
+func errorInterrupting(pid int, err error) error {
+	return fmt.Errorf("couldn't Interrupt pid(%d): %w", pid, err)
+}
+
+// ensureProcessDone attempts to work around flakey logic in os.Process Wait on Windows. This code block should be
+// revisited if https://golang.org/issue/25965 is solved.
+func ensureProcessDone(p *os.Process) error {
+	// Process.handle is not exported. Lookup the process again, using logic similar to exec_windows/findProcess()
+	const da = syscall.STANDARD_RIGHTS_READ | syscall.PROCESS_TERMINATE |
+		syscall.PROCESS_QUERY_INFORMATION | syscall.SYNCHRONIZE
+	h, e := syscall.OpenProcess(da, true, uint32(p.Pid))
+	if e != nil {
+		if errno, ok := e.(syscall.Errno); ok && uintptr(errno) == errorInvalidParameter {
+			return nil // don't error if the process isn't around anymore
+		}
+		return os.NewSyscallError("OpenProcess", e)
+	}
+	defer syscall.CloseHandle(h)
+
+	// Try to wait for the process to close naturally first, using logic from exec_windows/findProcess()
+	// Difference here, is we are waiting 100ms not infinite. If there's a timeout, we kill the proc.
+	s, e := syscall.WaitForSingleObject(h, 100)
+	switch s {
+	case syscall.WAIT_OBJECT_0:
+		return nil // process is no longer around
+	case syscall.WAIT_TIMEOUT:
+		return syscall.TerminateProcess(h, uint32(0)) // kill, but don't effect the exit code
+	case syscall.WAIT_FAILED:
+		return os.NewSyscallError("WaitForSingleObject", e)
+	default:
+		return errors.New("os: unexpected result from WaitForSingleObject")
+	}
+}
+
+func isExecutable(f os.FileInfo) bool { // In windows, we cannot read execute bit
+	return strings.HasSuffix(f.Name(), ".exe")
+}

--- a/internal/tar/tar_test.go
+++ b/internal/tar/tar_test.go
@@ -188,10 +188,10 @@ func TestUntarAndVerify_InvalidSignature(t *testing.T) {
 // requireTestFiles ensures the given directory includes the testdata/foo directory
 func requireTestFiles(t *testing.T, dst string) {
 	// NOTE: this will not include empty.txt as we don't want to clutter the tar with empty files
-	for _, path := range []string{"bar.sh", filepath.Join("bar", "baz.txt")} {
-		want, e := os.Stat(filepath.Join("testdata", "foo", path))
+	for _, p := range []string{"bar.sh", filepath.Join("bar", "baz.txt")} {
+		want, e := os.Stat(filepath.Join("testdata", "foo", p))
 		require.NoError(t, e)
-		have, e := os.Stat(filepath.Join(dst, path))
+		have, e := os.Stat(filepath.Join(dst, p))
 		require.NoError(t, e)
 		require.Equal(t, want.Mode(), have.Mode())
 	}

--- a/internal/test/envoy.go
+++ b/internal/test/envoy.go
@@ -90,13 +90,14 @@ func requireBuildFakeEnvoy(t *testing.T) []byte {
 	defer deleteTempDir()
 
 	name := "envoy"
+	bin := name + moreos.Exe
 	src := name + ".go"
 	require.NoError(t, os.WriteFile(filepath.Join(tempDir, src), fakeEnvoySrc, 0600))
-	cmd := exec.Command(goBin, "build", "-o", name, src) //nolint:gosec
+	cmd := exec.Command(goBin, "build", "-o", bin, src) //nolint:gosec
 	cmd.Dir = tempDir
 	out, err := cmd.CombinedOutput()
 	require.NoError(t, err, "couldn't compile %s: %s", src, string(out))
-	bytes, err := os.ReadFile(filepath.Join(tempDir, name))
+	bytes, err := os.ReadFile(filepath.Join(tempDir, bin))
 	require.NoError(t, err)
 	return bytes
 }


### PR DESCRIPTION
Before this change, we already had windows binaries available and some
functionality working. This makes the last adjustments needed for
Windows to pass both unit and end-to-end tests. While I can currently
use `make` personally, we shouldn't rely on it in Windows because paths
often have a space in them which makes make die. For that reason, the
GitHub Action is setup to use normal go instead.

Fixes #105