### PR TITLE
Adds hook to ensure Envoy exited

### DIFF
--- a/internal/moreos/moreos.go
+++ b/internal/moreos/moreos.go
@@ -63,6 +63,11 @@ func Interrupt(p *os.Process) error {
 	return interrupt(p) // un-exported to prevent godoc drift
 }
 
+// EnsureProcessDone makes sure the process has exited completely.
+func EnsureProcessDone(p *os.Process) error {
+	return ensureProcessDone(p) // un-exported to prevent godoc drift
+}
+
 // IsExecutable returns true if the input can be run as an exec.Cmd
 func IsExecutable(f os.FileInfo) bool {
 	return isExecutable(f)

--- a/internal/moreos/moreos_test.go
+++ b/internal/moreos/moreos_test.go
@@ -105,6 +105,26 @@ func TestProcessGroupAttr_Interrupt(t *testing.T) {
 	// Wait for the process to die; this could error due to the interrupt signal
 	cmd.Wait() //nolint
 	require.Error(t, findProcess(cmd.Process))
+
+	// Ensure interrupting it again doesn't error
+	require.NoError(t, Interrupt(cmd.Process))
+}
+
+func Test_EnsureProcessDone(t *testing.T) {
+	// Fork a process that hangs
+	cmd := exec.Command("cat" + Exe)
+	cmd.SysProcAttr = ProcessGroupAttr()
+	require.NoError(t, cmd.Start())
+
+	// Kill it
+	require.NoError(t, EnsureProcessDone(cmd.Process))
+
+	// Wait for the process to die; this could error due to the kill signal
+	cmd.Wait() //nolint
+	require.Error(t, findProcess(cmd.Process))
+
+	// Ensure killing it again doesn't error
+	require.NoError(t, EnsureProcessDone(cmd.Process))
 }
 
 func findProcess(proc *os.Process) error {

--- a/internal/moreos/proc_darwin.go
+++ b/internal/moreos/proc_darwin.go
@@ -26,7 +26,17 @@ func processGroupAttr() *syscall.SysProcAttr {
 }
 
 func interrupt(p *os.Process) error {
-	return p.Signal(syscall.SIGINT)
+	if err := p.Signal(syscall.SIGINT); err != nil && err != os.ErrProcessDone {
+		return err
+	}
+	return nil
+}
+
+func ensureProcessDone(p *os.Process) error {
+	if err := p.Kill(); err != nil && err != os.ErrProcessDone {
+		return err
+	}
+	return nil
 }
 
 func isExecutable(f os.FileInfo) bool {

--- a/internal/moreos/proc_linux.go
+++ b/internal/moreos/proc_linux.go
@@ -27,7 +27,17 @@ func processGroupAttr() *syscall.SysProcAttr {
 }
 
 func interrupt(p *os.Process) error {
-	return p.Signal(syscall.SIGINT)
+	if err := p.Signal(syscall.SIGINT); err != nil && err != os.ErrProcessDone {
+		return err
+	}
+	return nil
+}
+
+func ensureProcessDone(p *os.Process) error {
+	if err := p.Kill(); err != nil && err != os.ErrProcessDone {
+		return err
+	}
+	return nil
 }
 
 func isExecutable(f os.FileInfo) bool {


### PR DESCRIPTION
We currently don't ensure Envoy has exited when it said it should. Due the the nature of FS locks in windows, we can detect this happens sometimes in #309. This change adds the plumbing we can use on all supported operating systems.