### PR TITLE
Makes windows use zip instead of tar.gz

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -28,6 +28,13 @@ builds:
     goarch:
       - amd64
       - arm64
+
+archives:
+  - format: tar.gz
+    format_overrides:
+      - goos: windows
+        format: zip
+
 release:
   # Create a draft release in GitHub. We can write release notes manually.
   draft: true


### PR DESCRIPTION
zip is more idiomatic on that platform. I tested locally by pretending this commit was a release tag.


```bash
$ git tag -d v0.6.0
$ git tag v0.6.0
$ goreleaser-v0.173.2 release --skip-publish  --rm-dist
$ jar -tvf dist/func-e_0.6.0_windows_amd64.zip
 11337 Tue Jul 06 00:14:16 ChST 2021 LICENSE
  1177 Sat Jul 10 09:43:35 ChST 2021 README.md
7550976 Tue Jul 27 13:54:31 ChST 2021 func-e.exe
```