### PR TITLE
Automates updating official homebrew formula

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -58,3 +58,10 @@ jobs:
 
       - name: "Run e2e tests using released `func-e` binary"
         run: go test -parallel 1 -v -failfast ./e2e
+
+      - name: Bump homebrew-core formula
+        uses: mislav/bump-homebrew-formula-action@v1
+        with:
+          formula-name: func-e
+        env:  # same perms as `brew bump-formula-pr func-e --version 0.6.0`
+          COMMITTER_TOKEN: ${{ secrets.HOMEBREW_GITHUB_API_TOKEN }}


### PR DESCRIPTION
Last release, I manually did this:

```bash
$ brew bump-formula-pr func-e --version 0.6.0
```

This does the same, using the exact token which I added as a repo
secret.

fixes #317