### PR TITLE
Restricts default make config to single-entry GOPATH

### DIFF
--- a/.bingo/README.md
+++ b/.bingo/README.md
@@ -13,3 +13,4 @@ reference as a variable like `$(GOIMPORTS)`.
 
 This differs slightly from the defaults of the Bingo project:
 * ENV variable support is not included as this project only uses `make`
+* you must export GOBIN if your GOPATH includes multiple entries (helps Windows)

--- a/.bingo/Variables.mk
+++ b/.bingo/Variables.mk
@@ -2,9 +2,9 @@
 # All tools are designed to be build inside $GOBIN.
 BINGO_DIR := $(dir $(lastword $(MAKEFILE_LIST)))
 GOPATH ?= $(shell go env GOPATH)
-# This handles translation for Windows, but only in cygwin or similar environments
-PATHSEP := $(if $(COMSPEC),;,:)
-GOBIN  ?= $(firstword $(subst $(PATHSEP), ,$(subst \,/,${GOPATH})))/bin
+# We assume GOPATH has a single entry and those who don't must override GOBIN
+# While substituting path separators is easy, element separators is tricky due to c:\ in Windows.
+GOBIN  ?= $(subst \,/,${GOPATH})/bin
 GO     ?= $(shell which go)
 
 # Below generated variables ensure that every time a tool under each variable is invoked, the correct version

--- a/.github/workflows/commit.yaml
+++ b/.github/workflows/commit.yaml
@@ -39,40 +39,23 @@ jobs:
     strategy:
       fail-fast: false  # don't fail fast as sometimes failures are operating system specific
       matrix:
-        os: [ubuntu-latest, macos-latest]
-        include:
-          - os: windows-latest
-            # Until GHA allows a cygwin runner, we have to override the default bash
-            shell: C:\tools\cygwin\bin\bash.exe --login -o errexit -o nounset -o pipefail -o igncr -i {0}
+        # Note: Windows has certain tools pre-installed:
+        #  * candle/light: https://github.com/actions/virtual-environments/blob/main/images/win/scripts/Installers/Install-Wix.ps1
+        #  * make: https://github.com/actions/virtual-environments/blob/main/images/win/scripts/Installers/Install-Mingw64.ps1
+        os: [ubuntu-latest, macos-latest, windows-latest]
 
     defaults:
-      run:
-        shell: ${{ matrix.shell || 'bash' }}
+      run:  # use bash for all operating systems unless overridden
+        shell: bash
 
     steps:
-      # This sets up the environment we need for Windows, but isn't in the default image:
-      #  * install cygwin's bash which resolves paths correctly for .bingo/Variables.mk
-      #  * configure git so line-feeds don't trip lint https://github.com/actions/checkout/issues/135
-      #
-      # Note: Windows has certain tools pre-installed:
-      #  * candle/light: https://github.com/actions/virtual-environments/blob/main/images/win/scripts/Installers/Install-Wix.ps1
-      #  * make: https://github.com/actions/virtual-environments/blob/main/images/win/scripts/Installers/Install-Mingw64.ps1
-      - name: "Pre-configure (Windows)"
-        if: runner.os == 'Windows'
-        run: |
-          choco install -y --no-progress --source cygwin bash
+      - name: "Configure consistent line feeds"
+        run: |  # Temporary to avoid lint errors on Windows until https://github.com/actions/checkout/issues/135
           git config --global core.autocrlf input
           git config --global core.eol lf
-        shell: bash
 
       - name: "Checkout"
         uses: actions/checkout@v2
-
-      # The current working directory is lost when we run cygwin-bash in Windows.
-      # This ensures each new `run:` has the correct directory, and that it is correctly translated.
-      - name: "Ensure working directory (Windows)"
-        if: runner.os == 'Windows'
-        run: printf 'cd %s' "$(cygpath '${{ github.workspace }}')" >> ~/.bashrc
 
       - name: "Install Go"
         uses: actions/setup-go@v2


### PR DESCRIPTION
This restricts the default make config to single-entry GOPATH, which allows windows to work without hacks or cygwin.

Those who must use multiple-entry GOPATH will have to override GOBIN if they use our Makefile

See https://github.com/bwplotka/bingo/issues/26
This defers porting to go 1.17 #314