### PR TITLE
Uses separate workflow for version bumps

### DIFF
--- a/.github/workflows/bump.yaml
+++ b/.github/workflows/bump.yaml
@@ -1,0 +1,43 @@
+# `name` value will appear "as is" in the badge.
+# See https://docs.github.com/en/actions/configuring-and-managing-workflows/configuring-a-workflow#adding-a-workflow-status-badge-to-your-repository
+# yamllint --format github .github/workflows/bump.yaml
+---
+name: bump
+
+# This workflow is for external packages, and is only triggered once ("released").
+# This centralizes workflows that are hard to undo, such as reversing PRs that update packages.
+#
+# One trade-off of deferring to "released" is that release notes will refer to packages not yet
+# available. For example, homebrew raises a PR that needs to be merged, usually a day later.
+#
+# See https://docs.github.com/en/actions/reference/events-that-trigger-workflows?query=release+released+event#release
+# See https://docs.github.com/en/developers/webhooks-and-events/webhooks/webhook-events-and-payloads#release
+on:
+  release:
+    types:  # This triggers when a release is published, or a pre-release is changed to a release
+      - released
+
+# These pull requests create pull requests against a remote repository. This implies the following:
+#  1. Create TOKEN with "public_repo" scope https://github.com/settings/tokens
+#  2. Assign that as PACKAGE_BUMP_TOKEN https://github.com/organizations/tetratelabs/settings/secrets/actions/new
+#
+# To ensure PRs appear non-personal, use an org-specific name and the noreply email of tetratelabs
+# Ex. curl -s https://api.github.com/users/tetratelabs|jq '.id, .login'
+env:
+  GIT_USER_NAME: Tetrate Labs CI
+  GIT_USER_EMAIL: 38483186+tetratelabs@users.noreply.github.com
+
+jobs:
+  homebrew:
+    name: "Homebrew/homebrew-core"
+    runs-on: ubuntu-latest
+    steps:
+      # Shell, not bump-homebrew-formula-action, as this shows what's going on.
+      - name: "Bump Formula PR"
+        run: |
+          git config --global user.name "${GIT_USER_NAME}"
+          git config --global user.email "${GIT_USER_EMAIL}"
+          version="${GITHUB_REF#refs/tags/v}"
+          brew bump-formula-pr --no-browse --no-audit --version "${version}" func-e
+        env:  # See env section for notes on PACKAGE_BUMP_TOKEN
+          HOMEBREW_GITHUB_API_TOKEN: ${{ secrets.PACKAGE_BUMP_TOKEN }}

--- a/.github/workflows/commit.yaml
+++ b/.github/workflows/commit.yaml
@@ -36,6 +36,10 @@ on:
   # See https://docs.github.com/en/free-pro-team@latest/actions/managing-workflow-runs/manually-running-a-workflow
   workflow_dispatch:
 
+defaults:
+  run:  # use bash for all operating systems unless overridden
+    shell: bash
+
 jobs:
   test:
     name: "Run unit tests (${{ matrix.os }})"
@@ -45,9 +49,6 @@ jobs:
       fail-fast: false  # don't fail fast as sometimes failures are operating system specific
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-    defaults:
-      run:  # use bash for all operating systems unless overridden
-        shell: bash
 
     steps:
       - name: "Checkout"

--- a/.github/workflows/msi.yaml
+++ b/.github/workflows/msi.yaml
@@ -26,6 +26,10 @@ on:
   # See https://docs.github.com/en/free-pro-team@latest/actions/managing-workflow-runs/manually-running-a-workflow
   workflow_dispatch:
 
+defaults:
+  run:  # use bash for all operating systems unless overridden
+    shell: bash
+
 jobs:
   msi:
     name: "Test Windows Installer build (${{ matrix.os }})"
@@ -43,10 +47,6 @@ jobs:
           # wixtoolset isn't in the path https://github.com/wixtoolset/wix3/blob/develop/src/Setup/CoreMsi/Toolset.wxs#L87
           - os: windows-latest
             setup: echo "$WIX\\bin" >> $GITHUB_PATH
-
-    defaults:
-      run:  # use bash for all operating systems unless overridden
-        shell: bash
 
     steps:
       - name: "Setup msitools/wixtoolset"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,6 +11,10 @@ on:
 env:  # As of 2021-08-05 images come with go 1.15 https://github.com/actions/virtual-environments/tree/main/images
   GO_VERSION: "1.16.6"
 
+defaults:
+  run:  # use bash for all operating systems unless overridden
+    shell: bash
+
 jobs:
   func-e:
     name: "Release `func-e` CLI"
@@ -35,7 +39,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: "Add Windows installer (func-e.msi) to release"
+      - name: "Add Windows installer (func-e.msi) to the draft release"
         run: |  # manually until https://github.com/goreleaser/goreleaser/issues/1295
           tag="${GITHUB_REF#refs/tags/}"
           version=${tag#v}
@@ -64,10 +68,6 @@ jobs:
               printf "::set-output name=msi::%s\n" *.msi
               unzip -o *.zip && rm *.zip
 
-    defaults:
-      run:  # use bash for all operating systems unless overridden
-        shell: bash
-
     steps:
       - name: "Checkout"
         uses: actions/checkout@v2
@@ -85,7 +85,7 @@ jobs:
         env:  # authenticate as the release is a draft
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: "Run e2e tests using released `func-e` binary"
+      - name: "Run e2e tests using draft `func-e` binary"
         run: go test -parallel 1 -v -failfast ./e2e
 
       # This only checks the installer when built on Windows as it is simpler than switching OS.
@@ -103,14 +103,3 @@ jobs:
         env:  # use the stashed msi name instead of parsing in cmd
           MSI_FILE: ${{ steps.download.outputs.msi }}
 
-  homebrew:
-    needs: e2e
-    name: Bump homebrew-core formula
-    runs-on: ubuntu-latest
-    steps:
-      - name: Bump homebrew-core formula
-        uses: mislav/bump-homebrew-formula-action@v1
-        with:
-          formula-name: func-e
-        env:  # same perms as `brew bump-formula-pr func-e --version 0.6.0`
-          COMMITTER_TOKEN: ${{ secrets.HOMEBREW_GITHUB_API_TOKEN }}


### PR DESCRIPTION
This uses a separate workflow for version bumps, starting with homebrew (winget is likely next).

This allows us to centralize flows that are not file-driven, rather release driven. Particularly, actions that result in external pull requests would end up here.

This converts the homebrew bump to explicit commands and also removes the need to say "same perms as `brew bump-formula-pr func-e --version 0.6.0`" as we literally are using that command.

This also centralizes the token and identity of those pull requests so they are attributed to the org, not the person who created the token.