### PR TITLE
Adds which command

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -22,6 +22,7 @@ This value must be constant within a `$FUNC_E_HOME`.
 | run | Run Envoy with the given [arguments...] until interrupted |
 | versions | List Envoy versions |
 | use | Sets the current [version] used by the "run" command |
+| which | Prints the path to the Envoy binary used by the "run" command |
 | --version, -v | Print the version of func-e |
 
 # Environment Variables

--- a/e2e/func-e_which_test.go
+++ b/e2e/func-e_which_test.go
@@ -1,0 +1,33 @@
+// Copyright 2021 Tetrate
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package e2e
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/tetratelabs/func-e/internal/moreos"
+	"github.com/tetratelabs/func-e/internal/version"
+)
+
+func TestFuncEWhich(t *testing.T) { // not parallel as it can end up downloading concurrently
+	stdout, stderr, err := funcEExec("which")
+	relativeEnvoyBin := filepath.Join("versions", string(version.LastKnownEnvoy), "bin", "envoy"+moreos.Exe)
+	require.Contains(t, stdout, moreos.Sprintf("%s\n", relativeEnvoyBin))
+	require.Empty(t, stderr)
+	require.NoError(t, err)
+}

--- a/internal/cmd/app.go
+++ b/internal/cmd/app.go
@@ -99,6 +99,7 @@ func NewApp(o *globals.GlobalOpts) *cli.App {
 		NewRunCmd(o),
 		NewVersionsCmd(o),
 		NewUseCmd(o),
+		NewWhichCmd(o),
 	}
 	return app
 }

--- a/internal/cmd/help_test.go
+++ b/internal/cmd/help_test.go
@@ -29,7 +29,7 @@ import (
 )
 
 func TestFuncEHelp(t *testing.T) {
-	for _, command := range []string{"", "use", "versions", "run"} {
+	for _, command := range []string{"", "use", "versions", "run", "which"} {
 		command := command
 		t.Run(command, func(t *testing.T) {
 			c, stdout, _ := newApp(&globals.GlobalOpts{Version: "1.0", EnvoyVersion: "1.99.0"})

--- a/internal/cmd/run_test.go
+++ b/internal/cmd/run_test.go
@@ -112,7 +112,7 @@ func TestFuncERun_CreatesHomeVersionFile(t *testing.T) {
 	runWithoutConfig(t, c)
 
 	// We logged the implicit lookup
-	require.Contains(t, o.Out.(*bytes.Buffer).String(), moreos.Sprintf("looking up latest version"))
+	require.Contains(t, o.Out.(*bytes.Buffer).String(), moreos.Sprintf("looking up the latest Envoy version"))
 	require.FileExists(t, filepath.Join(o.HomeDir, "version"))
 	require.Equal(t, version.LastKnownEnvoy, o.EnvoyVersion)
 }
@@ -169,6 +169,6 @@ func TestFuncERun_ErrsWhenVersionsServerDown(t *testing.T) {
 	c, _, _ := newApp(o)
 	err := c.Run([]string{"func-e", "run"})
 
-	require.Contains(t, o.Out.(*bytes.Buffer).String(), moreos.Sprintf("looking up latest version"))
+	require.Contains(t, o.Out.(*bytes.Buffer).String(), moreos.Sprintf("looking up the latest Envoy version"))
 	require.Contains(t, err.Error(), fmt.Sprintf(`couldn't read latest version from %s`, o.EnvoyVersionsURL))
 }

--- a/internal/cmd/testdata/func-e_help.txt
+++ b/internal/cmd/testdata/func-e_help.txt
@@ -25,6 +25,7 @@ COMMANDS:
    run       Run Envoy with the given [arguments...] until interrupted
    versions  List Envoy versions
    use       Sets the current [version] used by the "run" command
+   which     Prints the path to the Envoy binary used by the "run" command
 
 GLOBAL OPTIONS:
    --home-dir value            func-e home directory (location of installed versions and run archives) (default: ${HOME}/.func-e) [$FUNC_E_HOME]

--- a/internal/cmd/testdata/func-e_which_help.txt
+++ b/internal/cmd/testdata/func-e_which_help.txt
@@ -1,0 +1,8 @@
+NAME:
+   func-e which - Prints the path to the Envoy binary used by the "run" command
+
+USAGE:
+   func-e which [arguments...]
+
+DESCRIPTION:
+   The binary is downloaded as necessary. The version is controllable by the "use" command

--- a/internal/cmd/which.go
+++ b/internal/cmd/which.go
@@ -1,0 +1,46 @@
+// Copyright 2021 Tetrate
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"github.com/urfave/cli/v2"
+
+	"github.com/tetratelabs/func-e/internal/envoy"
+	"github.com/tetratelabs/func-e/internal/globals"
+	"github.com/tetratelabs/func-e/internal/moreos"
+)
+
+// NewWhichCmd create a command responsible for downloading printing the path to the Envoy binary
+func NewWhichCmd(o *globals.GlobalOpts) *cli.Command {
+	return &cli.Command{
+		Name:        "which",
+		Usage:       `Prints the path to the Envoy binary used by the "run" command`,
+		Description: `The binary is downloaded as necessary. The version is controllable by the "use" command`,
+		Before: func(c *cli.Context) error {
+			// no logging on version query/download. This is deferred until we know we are executing "which"
+			o.Quiet = true
+			return ensureEnvoyVersion(c, o)
+		},
+		Action: func(c *cli.Context) error {
+			ev, err := envoy.InstallIfNeeded(c.Context, o, o.EnvoyVersion)
+			if err != nil {
+				return err
+			}
+			_, err = moreos.Fprintf(o.Out, "%s\n", ev)
+			return err
+		},
+		CustomHelpTemplate: moreos.Sprintf(cli.CommandHelpTemplate),
+	}
+}

--- a/internal/cmd/which_test.go
+++ b/internal/cmd/which_test.go
@@ -1,0 +1,41 @@
+// Copyright 2021 Tetrate
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd_test
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/tetratelabs/func-e/internal/moreos"
+)
+
+func (r *runner) Which(ctx context.Context, args []string) error {
+	return r.c.RunContext(ctx, args)
+}
+
+func TestFuncEWhich(t *testing.T) {
+	o, cleanup := setupTest(t)
+	defer cleanup()
+
+	c, stdout, stderr := newApp(o)
+
+	require.NoError(t, c.Run([]string{"func-e", "which"}))
+	envoyPath := filepath.Join(o.HomeDir, "versions", string(o.EnvoyVersion), "bin", "envoy"+moreos.Exe)
+	require.Equal(t, moreos.Sprintf("%s\n", envoyPath), stdout.String())
+	require.Empty(t, stderr)
+}

--- a/internal/envoy/install.go
+++ b/internal/envoy/install.go
@@ -62,8 +62,7 @@ func InstallIfNeeded(ctx context.Context, o *globals.GlobalOpts, v version.Versi
 		if err = os.MkdirAll(installPath, 0750); err != nil {
 			return "", fmt.Errorf("unable to create directory %q: %w", installPath, err)
 		}
-
-		moreos.Fprintf(o.Out, "downloading %s\n", tarballURL)                                     //nolint
+		o.Logf("downloading %s\n", tarballURL)                                                    //nolint
 		if err = untarEnvoy(ctx, installPath, tarballURL, sha256Sum, o.Platform, v); err != nil { //nolint
 			return "", err
 		}
@@ -71,7 +70,7 @@ func InstallIfNeeded(ctx context.Context, o *globals.GlobalOpts, v version.Versi
 			return "", fmt.Errorf("unable to set date of directory %q: %w", installPath, err)
 		}
 	case err == nil:
-		moreos.Fprintf(o.Out, "%s is already downloaded\n", v) //nolint
+		o.Logf("%s is already downloaded\n", v) //nolint
 	default:
 		// TODO: figure out how to get a stat error that isn't file not exist so we can test this
 		return "", err

--- a/internal/globals/globals.go
+++ b/internal/globals/globals.go
@@ -57,10 +57,20 @@ type GlobalOpts struct {
 	EnvoyVersion version.Version
 	// HomeDir is an absolute path which most importantly contains "versions" installed from EnvoyVersionsURL. Defaults to DefaultHomeDir
 	HomeDir string
+	// Quiet means don't Logf to Out
+	Quiet bool
 	// Out is where status messages are written. Defaults to os.Stdout
 	Out io.Writer
 	// The platform to target for the Envoy install.
 	Platform version.Platform
+}
+
+// Logf is used for shared functions that log conditionally on GlobalOpts.Quiet
+func (o *GlobalOpts) Logf(format string, a ...interface{}) {
+	if o.Quiet { // TODO: we may want to do scoped logging via a Context property, if this becomes common.
+		return
+	}
+	moreos.Fprintf(o.Out, format, a...) //nolint
 }
 
 const (


### PR DESCRIPTION
This adds a `which` command that prints the path to the Envoy binary
that would be run.

Ex.
```bash
$ func-e which
/Users/adrian/.func-e/versions/1.19.0/bin/envoy
```

This allows func-e to install, but not run envoy for scenarios such as building other images.

Ex. the following are equivalent:
```bash
$ $(func-e which) --version
$ func-e run --version
```