### PR TITLE
Runs e2e on centos 8

### DIFF
--- a/.github/workflows/commit.yaml
+++ b/.github/workflows/commit.yaml
@@ -97,3 +97,48 @@ jobs:
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         run: bash <(curl -s https://codecov.io/bash)
+
+  # Github Action Runners don't support all operating systems we may need to test. Below ensures
+  # we run on the intended minimum platforms. Note: we also use Travis for arm64+ubuntu.
+  #
+  # Use only images from internal-images.yaml to avoid Docker rate limits and slow install steps.
+  test-e2e:
+    name: "Run e2e tests via containers (${{ matrix.os }})"
+    runs-on: ubuntu-latest
+    # "When you only specify a container image, you can omit the image keyword."
+    # See https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idcontainer
+    container: ${{ matrix.container }}
+    timeout-minutes: 90  # instead of 360 by default
+    strategy:
+      fail-fast: false  # don't fail fast as sometimes failures are operating system specific
+      matrix:
+        container: ["ghcr.io/tetratelabs/func-e-internal:centos8"]
+
+    steps:
+      - name: "Checkout"
+        uses: actions/checkout@v2
+
+      - name: "Install Go"
+        uses: actions/setup-go@v2
+        with:
+          go-version: ${{ env.GO_VERSION }}
+
+      - name: "Cache golang"
+        uses: actions/cache@v2
+        with:
+          path: |  # TODO: go build cache if we care, noting it is OS-specific
+            ~/go/pkg/mod
+            ~/go/bin/*-v*
+          # '.bingo/*.sum' files generate inconsistently when building `~/go/bin/*-v*`. We key '.bingo/*.mod' instead.
+          key: test-${{ runner.os }}-${{ env.GO_VERSION }}-go-${{ hashFiles('go.sum', '.bingo/*.mod') }}
+          restore-keys: test-${{ runner.os }}-${{ env.GO_VERSION }}-go-
+
+      - name: "Cache Envoy binaries"
+        uses: actions/cache@v2
+        with:  # ~/.func-e/versions is cached so that we only re-download once: for TestFuncEInstall
+          path: ~/.func-e/versions
+          key: test-${{ runner.os }}-envoy-${{ hashFiles('internal/version/last_known_envoy.txt') }}
+          restore-keys: test-${{ runner.os }}-envoy-
+
+      - name: "Run e2e tests using the `func-e` binary"
+        run: make e2e

--- a/.github/workflows/commit.yaml
+++ b/.github/workflows/commit.yaml
@@ -103,7 +103,7 @@ jobs:
   #
   # Use only images from internal-images.yaml to avoid Docker rate limits and slow install steps.
   test-e2e:
-    name: "Run e2e tests via containers (${{ matrix.os }})"
+    name: "Run e2e tests via containers (${{ matrix.container }})"
     runs-on: ubuntu-latest
     # "When you only specify a container image, you can omit the image keyword."
     # See https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idcontainer

--- a/.github/workflows/internal-images.yml
+++ b/.github/workflows/internal-images.yml
@@ -1,0 +1,52 @@
+# yamllint --format github .github/workflows/internal-images.yml
+---
+name: internal-images
+
+# Refresh the tags once a day
+on:
+  schedule:
+    - cron: "23 3 * * *"
+  workflow_dispatch:  # Allows manual refresh
+
+# This builds images and pushes them to ghcr.io/tetratelabs/func-e-internal:$tag
+# Using these in tests and as a parent (FROM) avoids docker.io rate-limits particularly on pull requests.
+#
+# To troubleshoot, run locally with docker and install go directly. Ex:
+# ```bash
+# $ docker run -ti -v $PWD:/func-e --rm centos:8
+# [root@d37da4601545 /]# cd /func-e
+# [root@d37da4601545 func-e]# eval "$(curl -sL https://raw.githubusercontent.com/travis-ci/gimme/master/gimme | GIMME_GO_VERSION=1.16.6 bash)"
+# now execute your setup commands!
+# ```
+jobs:
+  copy-images:
+    strategy:
+      matrix:
+        # Be precise in tag versions to improve reproducibility
+        include:
+          - dockerfile: |
+              FROM centos:8
+              RUN yum install -y --quiet make which git gcc && yum clean all
+            target_tag: centos8
+    runs-on: ubuntu-latest
+    steps:
+      # Same as doing this locally: echo "${GHCR_TOKEN}" | docker login ghcr.io -u "${GHCR_TOKEN}" --password-stdin
+      - name: Login into GitHub Container Registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          # GHCR_TOKEN=<hex token value>
+          #   - pushes Docker images to ghcr.io
+          #   - create via https://github.com/settings/tokens
+          #   - assign via https://github.com/organizations/tetratelabs/settings/secrets/actions
+          #   - needs repo:status, public_repo, write:packages, delete:packages
+          password: ${{ secrets.GHCR_TOKEN }}
+
+      - name: Build and push
+        run: |  # This will only push a single architecture, which is fine as we currently only support amd64
+          cat > Dockerfile <<'EOF'
+          ${{ matrix.dockerfile }}
+          EOF
+          docker build -t ghcr.io/tetratelabs/func-e-internal:${{ matrix.target_tag }} .
+          docker push ghcr.io/tetratelabs/func-e-internal:${{ matrix.target_tag }}

--- a/.github/workflows/internal-images.yml
+++ b/.github/workflows/internal-images.yml
@@ -19,7 +19,7 @@ on:
 # now execute your setup commands!
 # ```
 jobs:
-  copy-images:
+  build-and-push-images:
     strategy:
       matrix:
         # Be precise in tag versions to improve reproducibility

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ virt: lxd  # faster starting
 language: go
 
 go:
-  - 1.16.5
+  - 1.16.6
 
 cache:
   directories: # ~/.func-e/versions is cached so that we only re-download once: for TestFuncEInstall
@@ -22,7 +22,7 @@ if: (type = push AND branch = master) OR type = pull_request
 
 before_install: |  # Prevent test build of a documentation or GitHub Actions only change.
   if [ -n "${TRAVIS_COMMIT_RANGE}" ] && ! git diff --name-only "${TRAVIS_COMMIT_RANGE}" -- \
-    grep -qvE '(\.md)$|'(\.wks)$|^(site\/)|^(netlify.toml)|^(.github\/)'; then
+    grep -qvE '(\.md)$|^(packaging\/)$|^(site\/)|^(netlify.toml)|^(.github\/)'; then
     echo "Stopping job as changes are tested with GitHub Actions"
     travis_terminate 0
   fi


### PR DESCRIPTION
centos isn't a supported runner in GHA or travis, but you can run it via container with GHA.
We need to use an internal image to avoid rate limiting and 12minutes to install prereqs

See #338 