### PR TITLE
sleep to prevent flakes  on delayed windows installer service

### DIFF
--- a/packaging/msi/verify_msi.cmd
+++ b/packaging/msi/verify_msi.cmd
@@ -18,6 +18,8 @@
 if not defined MSI_FILE set MSI_FILE=dist\func-e_windows_amd64\func-e.msi
 echo installing %MSI_FILE%
 msiexec /i %MSI_FILE% /qn || exit /b 1
+:: sleep to prevent slow CI hosts from flaking on delayed installer service
+sleep 2
 
 :: Use chocolatey tool to refresh the current PATH without exiting the shell
 call RefreshEnv.cmd
@@ -27,6 +29,8 @@ func-e -version || exit /b 1
 
 echo uninstalling func-e
 msiexec /x %MSI_FILE% /qn || exit /b 1
+:: sleep to prevent slow CI hosts from flaking on delayed installer service
+sleep 2
 
 echo ensuring func-e was uninstalled
 func-e -version && exit /b 1


### PR DESCRIPTION
hopefully, this will prevent a flake like this https://github.com/tetratelabs/func-e/runs/3318938205

I used 2 seconds because that's the last magic number choco uses https://github.com/chocolatey/choco/blob/master/src/chocolatey/infrastructure.app/services/AutomaticUninstallerService.cs#L41
