### PR TITLE
Ensures release testing of Windows installer works

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -105,7 +105,9 @@ jobs:
       # refreshenv is from choco, and lets you reload ENV variables (used here for PATH).
       - name: "Test Windows Installer (Windows)"
         if: runner.os == 'Windows'
-        run: call packaging\msi\verify_msi.cmd
+        run: |  # delete func-e.exe which was just tested, so it doesn't taint the tests
+          del func-e.exe
+          call packaging\msi\verify_msi.cmd
         shell: cmd
         env:  # use the stashed msi name instead of parsing it
           MSI_FILE: ${{ steps.download.outputs.msi }}

--- a/packaging/msi/verify_msi.cmd
+++ b/packaging/msi/verify_msi.cmd
@@ -18,8 +18,6 @@
 if not defined MSI_FILE set MSI_FILE=dist\func-e_windows_amd64\func-e.msi
 echo installing %MSI_FILE%
 msiexec /i %MSI_FILE% /qn || exit /b 1
-:: sleep to prevent slow CI hosts from flaking on delayed installer service
-sleep 2
 
 :: Use chocolatey tool to refresh the current PATH without exiting the shell
 call RefreshEnv.cmd
@@ -29,8 +27,6 @@ func-e -version || exit /b 1
 
 echo uninstalling func-e
 msiexec /x %MSI_FILE% /qn || exit /b 1
-:: sleep to prevent slow CI hosts from flaking on delayed installer service
-sleep 2
 
 echo ensuring func-e was uninstalled
 func-e -version && exit /b 1


### PR DESCRIPTION
This reverts #341 as the root problem was a leftover file.
