### PR TITLE
Removes test utilities for built-ins

### DIFF
--- a/internal/cmd/app_test.go
+++ b/internal/cmd/app_test.go
@@ -28,7 +28,6 @@ import (
 	rootcmd "github.com/tetratelabs/func-e/internal/cmd"
 	"github.com/tetratelabs/func-e/internal/globals"
 	"github.com/tetratelabs/func-e/internal/test"
-	"github.com/tetratelabs/func-e/internal/test/morerequire"
 	"github.com/tetratelabs/func-e/internal/version"
 )
 
@@ -57,10 +56,9 @@ func TestFuncEValidateArgs(t *testing.T) {
 
 func TestHomeDir(t *testing.T) {
 	type testCase struct {
-		name string
-		args []string
-		// setup returns a tear-down function
-		setup    func() func()
+		name     string
+		args     []string
+		setup    func()
 		expected string
 	}
 
@@ -79,8 +77,8 @@ func TestHomeDir(t *testing.T) {
 		{
 			name: "FUNC_E_HOME env",
 			args: []string{"func-e"},
-			setup: func() func() {
-				return morerequire.RequireSetenv(t, "FUNC_E_HOME", alt1)
+			setup: func() {
+				t.Setenv("FUNC_E_HOME", alt1)
 			},
 			expected: alt1,
 		},
@@ -92,8 +90,8 @@ func TestHomeDir(t *testing.T) {
 		{
 			name: "prioritizes --home-dir arg over FUNC_E_HOME env",
 			args: []string{"func-e", "--home-dir", alt1},
-			setup: func() func() {
-				return morerequire.RequireSetenv(t, "FUNC_E_HOME", alt2)
+			setup: func() {
+				t.Setenv("FUNC_E_HOME", alt2)
 			},
 			expected: alt1,
 		},
@@ -104,8 +102,7 @@ func TestHomeDir(t *testing.T) {
 
 		t.Run(tc.name, func(t *testing.T) {
 			if tc.setup != nil {
-				tearDown := tc.setup()
-				defer tearDown()
+				tc.setup()
 			}
 
 			o := &globals.GlobalOpts{}
@@ -119,10 +116,9 @@ func TestHomeDir(t *testing.T) {
 
 func TestPlatformArg(t *testing.T) {
 	type testCase struct {
-		name string
-		args []string
-		// setup returns a tear-down function
-		setup    func() func()
+		name     string
+		args     []string
+		setup    func()
 		expected version.Platform
 	}
 
@@ -130,8 +126,8 @@ func TestPlatformArg(t *testing.T) {
 		{
 			name: "FUNC_E_PLATFORM env",
 			args: []string{"func-e"},
-			setup: func() func() {
-				return morerequire.RequireSetenv(t, "FUNC_E_PLATFORM", "linux/amd64")
+			setup: func() {
+				t.Setenv("FUNC_E_PLATFORM", "linux/amd64")
 			},
 			expected: version.Platform("linux/amd64"),
 		},
@@ -147,8 +143,7 @@ func TestPlatformArg(t *testing.T) {
 
 		t.Run(tc.name, func(t *testing.T) {
 			if tc.setup != nil {
-				tearDown := tc.setup()
-				defer tearDown()
+				tc.setup()
 			}
 
 			o := &globals.GlobalOpts{}
@@ -162,10 +157,9 @@ func TestPlatformArg(t *testing.T) {
 
 func TestEnvoyVersionsURL(t *testing.T) {
 	type testCase struct {
-		name string
-		args []string
-		// setup returns a tear-down function
-		setup    func() func()
+		name     string
+		args     []string
+		setup    func()
 		expected string
 	}
 
@@ -178,8 +172,8 @@ func TestEnvoyVersionsURL(t *testing.T) {
 		{
 			name: "ENVOY_VERSIONS_URL env",
 			args: []string{"func-e"},
-			setup: func() func() {
-				return morerequire.RequireSetenv(t, "ENVOY_VERSIONS_URL", "http://ENVOY_VERSIONS_URL/env")
+			setup: func() {
+				t.Setenv("ENVOY_VERSIONS_URL", "http://ENVOY_VERSIONS_URL/env")
 			},
 			expected: "http://ENVOY_VERSIONS_URL/env",
 		},
@@ -191,8 +185,8 @@ func TestEnvoyVersionsURL(t *testing.T) {
 		{
 			name: "prioritizes --envoy-versions-url arg over ENVOY_VERSIONS_URL env",
 			args: []string{"func-e", "--envoy-versions-url", "http://versions/arg"},
-			setup: func() func() {
-				return morerequire.RequireSetenv(t, "ENVOY_VERSIONS_URL", "http://ENVOY_VERSIONS_URL/env")
+			setup: func() {
+				t.Setenv("ENVOY_VERSIONS_URL", "http://ENVOY_VERSIONS_URL/env")
 			},
 			expected: "http://versions/arg",
 		},
@@ -203,8 +197,7 @@ func TestEnvoyVersionsURL(t *testing.T) {
 
 		t.Run(tc.name, func(t *testing.T) {
 			if tc.setup != nil {
-				tearDown := tc.setup()
-				defer tearDown()
+				tc.setup()
 			}
 
 			o := &globals.GlobalOpts{}

--- a/internal/cmd/versions_cmd_test.go
+++ b/internal/cmd/versions_cmd_test.go
@@ -98,8 +98,7 @@ func TestFuncEVersions_CurrentVersion(t *testing.T) {
 	})
 
 	t.Run("set by $ENVOY_VERSION", func(t *testing.T) {
-		revertEnv := morerequire.RequireSetenv(t, "ENVOY_VERSION", "1.2.1")
-		defer revertEnv()
+		t.Setenv("ENVOY_VERSION", "1.2.1")
 
 		c, stdout, _ := newApp(o)
 		require.NoError(t, c.Run([]string{"func-e", "versions"}))

--- a/internal/envoy/version_test.go
+++ b/internal/envoy/version_test.go
@@ -152,8 +152,7 @@ func TestCurrentVersion(t *testing.T) {
 		require.NoError(t, err)
 	})
 
-	revert := morerequire.RequireSetenv(t, "ENVOY_VERSION", "3.3.3")
-	defer revert()
+	t.Setenv("ENVOY_VERSION", "3.3.3")
 
 	t.Run("prefers $ENVOY_VERSION over $PWD/.envoy-version", func(t *testing.T) {
 		v, source, err := CurrentVersion(homeDir)
@@ -193,8 +192,7 @@ func TestCurrentVersion_Validates(t *testing.T) {
 		require.Contains(t, err.Error(), expectedErr)
 	})
 
-	revert := morerequire.RequireSetenv(t, "ENVOY_VERSION", "c.c.c")
-	defer revert()
+	t.Setenv("ENVOY_VERSION", "c.c.c")
 
 	t.Run("validates $ENVOY_VERSION", func(t *testing.T) {
 		_, _, err := CurrentVersion(homeDir)

--- a/internal/test/morerequire/morerequire.go
+++ b/internal/test/morerequire/morerequire.go
@@ -31,21 +31,6 @@ func RequireSetMtime(t *testing.T, dir, date string) {
 	require.NoError(t, os.Chtimes(dir, td, td))
 }
 
-// RequireSetenv will os.Setenv the given key and value. The function returned reverts to the original.
-func RequireSetenv(t *testing.T, key, value string) func() {
-	previous := os.Getenv(key)
-	err := os.Setenv(key, value)
-	require.NoError(t, err, `error setting env variable %s=%s`, key, value)
-	return func() {
-		if previous != "" {
-			err = os.Setenv(key, previous)
-		} else {
-			err = os.Unsetenv(key)
-		}
-		require.NoError(t, err, `error reverting env variable %s=%s`, key, previous)
-	}
-}
-
 // RequireChdir changes the working directory reverts it on the returned function
 func RequireChdir(t *testing.T, dir string) func() {
 	wd, err := os.Getwd()


### PR DESCRIPTION
Notably, this uses the go 1.17 https://pkg.go.dev/testing#T.Setenv
