### PR TITLE
Cleans up tests

### DIFF
--- a/e2e/func-e_run_test.go
+++ b/e2e/func-e_run_test.go
@@ -61,8 +61,8 @@ func TestFuncERun(t *testing.T) {
 func TestFuncERun_StaticFilesystem(t *testing.T) {
 	t.Parallel() // uses random ports so safe to run parallel
 
-	revertTempWd := morerequire.RequireChdirIntoTemp(t)
-	defer revertTempWd()
+	revertWd := morerequire.RequireChdir(t, t.TempDir())
+	defer revertWd()
 
 	require.NoError(t, os.WriteFile("envoy.yaml", staticFilesystemConfig, 0600))
 	responseFromRunDirectory := []byte("foo")
@@ -190,8 +190,7 @@ func requireEnvoyPid(t *testing.T, c *funcE) {
 
 // Run deletes the run directory after making a tar.gz with the same name. This extracts it and tests the contents.
 func verifyRunArchive(t *testing.T, c *funcE) {
-	runDir, removeRunDir := morerequire.RequireNewTempDir(t)
-	defer removeRunDir()
+	runDir := t.TempDir()
 
 	runArchive := c.runDir + ".tar.gz"
 	src, err := os.Open(runArchive)

--- a/e2e/func-e_use_test.go
+++ b/e2e/func-e_use_test.go
@@ -23,14 +23,12 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/tetratelabs/func-e/internal/moreos"
-	"github.com/tetratelabs/func-e/internal/test/morerequire"
 	"github.com/tetratelabs/func-e/internal/version"
 )
 
 // TestFuncEUse needs to always execute, so we run it in a separate home directory
 func TestFuncEUse(t *testing.T) {
-	homeDir, removeHomeDir := morerequire.RequireNewTempDir(t)
-	defer removeHomeDir()
+	homeDir := t.TempDir()
 
 	t.Run("not yet installed", func(t *testing.T) {
 		stdout, stderr, err := funcEExec("--home-dir", homeDir, "use", string(version.LastKnownEnvoy))

--- a/e2e/func-e_versions_test.go
+++ b/e2e/func-e_versions_test.go
@@ -22,13 +22,11 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/tetratelabs/func-e/internal/test/morerequire"
 	"github.com/tetratelabs/func-e/internal/version"
 )
 
 func TestFuncEVersions_NothingYet(t *testing.T) {
-	homeDir, removeHomeDir := morerequire.RequireNewTempDir(t)
-	defer removeHomeDir()
+	homeDir := t.TempDir()
 
 	stdout, stderr, err := funcEExec("--home-dir", homeDir, "versions")
 

--- a/internal/cmd/app_test.go
+++ b/internal/cmd/app_test.go
@@ -250,8 +250,7 @@ func setupTest(t *testing.T) (*globals.GlobalOpts, func()) {
 	result.Out = io.Discard // ignore logging by default
 	var tearDown []func()
 
-	tempDir, deleteTempDir := morerequire.RequireNewTempDir(t)
-	tearDown = append(tearDown, deleteTempDir)
+	tempDir := t.TempDir()
 
 	result.HomeDir = filepath.Join(tempDir, "envoy_home")
 	err := os.Mkdir(result.HomeDir, 0700)

--- a/internal/cmd/run_test.go
+++ b/internal/cmd/run_test.go
@@ -65,7 +65,11 @@ func TestFuncERun(t *testing.T) {
 
 	require.NoError(t, err)
 	require.Empty(t, stdout)
-	require.Equal(t, moreos.Sprintf("initializing epoch 0\nstarting main dispatch loop\n"), stderr.String())
+	require.Equal(t, moreos.Sprintf(`initializing epoch 0
+starting main dispatch loop
+caught SIGINT
+exiting
+`), stderr.String())
 }
 
 func TestFuncERun_TeesConsoleToLogs(t *testing.T) {

--- a/internal/cmd/run_test.go
+++ b/internal/cmd/run_test.go
@@ -65,11 +65,12 @@ func TestFuncERun(t *testing.T) {
 
 	require.NoError(t, err)
 	require.Empty(t, stdout)
-	require.Equal(t, moreos.Sprintf(`initializing epoch 0
+	// Rather than polling until we see "exiting", we just check we got up to point of signal caught.
+	// This de-flakes Windows which only sometimes reads "exiting" in CI.
+	require.Contains(t, stderr.String(), moreos.Sprintf(`initializing epoch 0
 starting main dispatch loop
 caught SIGINT
-exiting
-`), stderr.String())
+`))
 }
 
 func TestFuncERun_TeesConsoleToLogs(t *testing.T) {

--- a/internal/cmd/versions_cmd_test.go
+++ b/internal/cmd/versions_cmd_test.go
@@ -85,8 +85,8 @@ func TestFuncEVersions_CurrentVersion(t *testing.T) {
 	})
 
 	t.Run("set by $PWD/.envoy-version", func(t *testing.T) {
-		revertTempWd := morerequire.RequireChdirIntoTemp(t)
-		defer revertTempWd()
+		revertWd := morerequire.RequireChdir(t, t.TempDir())
+		defer revertWd()
 		require.NoError(t, os.WriteFile(".envoy-version", []byte("1.2.2"), 0600))
 
 		c, stdout, _ := newApp(o)

--- a/internal/cmd/versions_test.go
+++ b/internal/cmd/versions_test.go
@@ -32,8 +32,7 @@ func TestGetInstalledVersions_ErrorsWhenFileIsInVersionsDir(t *testing.T) {
 		t.SkipNow() // golang/go#46734 wrong error on file where directory should be
 	}
 
-	homeDir, removeHomeDir := morerequire.RequireNewTempDir(t)
-	defer removeHomeDir()
+	homeDir := t.TempDir()
 
 	versionsDir := filepath.Join(homeDir, "versions")
 	require.NoError(t, os.WriteFile(versionsDir, []byte{}, 0700))
@@ -43,8 +42,7 @@ func TestGetInstalledVersions_ErrorsWhenFileIsInVersionsDir(t *testing.T) {
 }
 
 func TestGetInstalledVersions_MissingOrEmptyVersionsDir(t *testing.T) {
-	homeDir, removeHomeDir := morerequire.RequireNewTempDir(t)
-	defer removeHomeDir()
+	homeDir := t.TempDir()
 
 	rows, err := getInstalledVersions(homeDir)
 	require.NoError(t, err) // ensures we don't error just because nothing is installed yet.
@@ -60,8 +58,7 @@ func TestGetInstalledVersions_MissingOrEmptyVersionsDir(t *testing.T) {
 }
 
 func TestGetInstalledVersions_ReleaseDateFromMtime(t *testing.T) {
-	homeDir, removeHomeDir := morerequire.RequireNewTempDir(t)
-	defer removeHomeDir()
+	homeDir := t.TempDir()
 
 	oneOneTwo := filepath.Join(homeDir, "versions", "1.1.2")
 	require.NoError(t, os.MkdirAll(oneOneTwo, 0700))
@@ -73,8 +70,7 @@ func TestGetInstalledVersions_ReleaseDateFromMtime(t *testing.T) {
 }
 
 func TestGetInstalledVersions_SkipsFileInVersionsDir(t *testing.T) {
-	homeDir, removeHomeDir := morerequire.RequireNewTempDir(t)
-	defer removeHomeDir()
+	homeDir := t.TempDir()
 
 	// make the versions directory
 	versionsDir := filepath.Join(homeDir, "versions")

--- a/internal/envoy/run_test.go
+++ b/internal/envoy/run_test.go
@@ -57,7 +57,7 @@ func TestRuntime_Run(t *testing.T) {
 			name: "func-e Ctrl+C",
 			args: []string{"-c", "envoy.yaml"},
 			// Don't warn the user when they exited the process
-			expectedStdout:   moreos.Sprintf("starting: %s -c envoy.yaml %s\nGET /ready HTTP/1.1\n", fakeEnvoy, adminFlag),
+			expectedStdout:   moreos.Sprintf("starting: %s -c envoy.yaml %s\n", fakeEnvoy, adminFlag),
 			expectedStderr:   moreos.Sprintf("initializing epoch 0\nstarting main dispatch loop\ncaught SIGINT\nexiting\n"),
 			wantShutdownHook: true,
 		},

--- a/internal/envoy/run_test.go
+++ b/internal/envoy/run_test.go
@@ -31,12 +31,10 @@ import (
 	"github.com/tetratelabs/func-e/internal/globals"
 	"github.com/tetratelabs/func-e/internal/moreos"
 	"github.com/tetratelabs/func-e/internal/test"
-	"github.com/tetratelabs/func-e/internal/test/morerequire"
 )
 
 func TestRuntime_Run(t *testing.T) {
-	tempDir, removeTempDir := morerequire.RequireNewTempDir(t)
-	defer removeTempDir()
+	tempDir := t.TempDir()
 
 	runsDir := filepath.Join(tempDir, "runs")
 	runDir := filepath.Join(runsDir, "1619574747231823000") // fake a realistic value

--- a/internal/envoy/runtime.go
+++ b/internal/envoy/runtime.go
@@ -22,6 +22,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"syscall"
 	"time"
 
 	"github.com/tetratelabs/func-e/internal/globals"
@@ -55,6 +56,31 @@ type Runtime struct {
 	FakeInterrupt context.CancelFunc
 
 	shutdownHooks []func(context.Context) error
+}
+
+// String is only used in tests. It is slow, but helps when debugging CI failures
+func (r *Runtime) String() string {
+	var stdout, stderr string
+	if r.OutFile != nil {
+		if b, err := os.ReadFile(r.OutFile.Name()); err == nil {
+			stdout = string(b)
+		}
+	}
+
+	if r.ErrFile != nil {
+		if b, err := os.ReadFile(r.ErrFile.Name()); err == nil {
+			stderr = string(b)
+		}
+	}
+
+	exitStatus := -1
+	if r.cmd != nil && r.cmd.ProcessState != nil {
+		if ws, ok := r.cmd.ProcessState.Sys().(syscall.WaitStatus); ok {
+			exitStatus = ws.ExitStatus()
+		}
+	}
+
+	return fmt.Sprintf("{stdout: %s, stderr: %s, exitStatus: %d}", stdout, stderr, exitStatus)
 }
 
 // GetRunDir returns the run-specific directory files can be written to.

--- a/internal/envoy/shutdown/admin_test.go
+++ b/internal/envoy/shutdown/admin_test.go
@@ -27,12 +27,10 @@ import (
 	"github.com/tetratelabs/func-e/internal/globals"
 	"github.com/tetratelabs/func-e/internal/moreos"
 	"github.com/tetratelabs/func-e/internal/test"
-	"github.com/tetratelabs/func-e/internal/test/morerequire"
 )
 
 func TestEnableEnvoyAdminDataCollection(t *testing.T) {
-	runDir, removeRunDir := morerequire.RequireNewTempDir(t)
-	defer removeRunDir()
+	runDir := t.TempDir()
 
 	require.NoError(t, runWithShutdownHook(t, runDir, enableEnvoyAdminDataCollection))
 

--- a/internal/envoy/shutdown/admin_test.go
+++ b/internal/envoy/shutdown/admin_test.go
@@ -17,8 +17,6 @@ package shutdown
 import (
 	"bytes"
 	"io"
-	"net/http"
-	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"testing"
@@ -36,17 +34,7 @@ func TestEnableEnvoyAdminDataCollection(t *testing.T) {
 	runDir, removeRunDir := morerequire.RequireNewTempDir(t)
 	defer removeRunDir()
 
-	mockAdmin := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusOK)
-		w.Write([]byte("junk"))
-	}))
-	defer mockAdmin.Close()
-
-	adminPath := filepath.Join(runDir, "admin-address.txt")
-	err := os.WriteFile(adminPath, []byte(mockAdmin.Listener.Addr().String()), 0600)
-	require.NoError(t, err)
-
-	runWithShutdownHook(t, runDir, enableEnvoyAdminDataCollection, `--admin-address-path`, adminPath)
+	require.NoError(t, runWithShutdownHook(t, runDir, enableEnvoyAdminDataCollection))
 
 	for _, filename := range adminAPIPaths {
 		path := filepath.Join(runDir, filename)
@@ -57,7 +45,7 @@ func TestEnableEnvoyAdminDataCollection(t *testing.T) {
 }
 
 // runWithShutdownHook is like RequireRun, except invokes the hook on shutdown
-func runWithShutdownHook(t *testing.T, runDir string, hook func(r *envoy.Runtime) error, args ...string) error {
+func runWithShutdownHook(t *testing.T, runDir string, hook func(r *envoy.Runtime) error) error {
 	fakeEnvoy := filepath.Join(runDir, "envoy"+moreos.Exe)
 	test.RequireFakeEnvoy(t, fakeEnvoy)
 
@@ -74,5 +62,5 @@ func runWithShutdownHook(t *testing.T, runDir string, hook func(r *envoy.Runtime
 		if fakeInterrupt != nil {
 			fakeInterrupt()
 		}
-	}, r, stderr, args...)
+	}, r, stderr, "-c", "envoy.yaml")
 }

--- a/internal/envoy/shutdown/node_test.go
+++ b/internal/envoy/shutdown/node_test.go
@@ -27,14 +27,14 @@ import (
 )
 
 func TestEnableNodeCollection(t *testing.T) {
-	workingDir, removeWorkingDir := morerequire.RequireNewTempDir(t)
-	defer removeWorkingDir()
+	runDir, removeRunDir := morerequire.RequireNewTempDir(t)
+	defer removeRunDir()
 
-	runWithShutdownHook(t, workingDir, enableNodeCollection)
+	require.NoError(t, runWithShutdownHook(t, runDir, enableNodeCollection))
 
 	files := [...]string{"node/ps.txt", "node/network_interface.json", "node/connections.json"}
 	for _, file := range files {
-		path := filepath.Join(workingDir, file)
+		path := filepath.Join(runDir, file)
 		f, err := os.Stat(path)
 		require.NoError(t, err, "error stating %v", path)
 

--- a/internal/envoy/shutdown/node_test.go
+++ b/internal/envoy/shutdown/node_test.go
@@ -22,13 +22,10 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-
-	"github.com/tetratelabs/func-e/internal/test/morerequire"
 )
 
 func TestEnableNodeCollection(t *testing.T) {
-	runDir, removeRunDir := morerequire.RequireNewTempDir(t)
-	defer removeRunDir()
+	runDir := t.TempDir()
 
 	require.NoError(t, runWithShutdownHook(t, runDir, enableNodeCollection))
 

--- a/internal/moreos/moreos_test.go
+++ b/internal/moreos/moreos_test.go
@@ -26,8 +26,6 @@ import (
 
 	"github.com/shirou/gopsutil/v3/process"
 	"github.com/stretchr/testify/require"
-
-	"github.com/tetratelabs/func-e/internal/test/morerequire"
 )
 
 // TestErrorWithWindowsPathSeparator makes sure errors don't accidentally escape the windows path separator.
@@ -44,8 +42,7 @@ func TestErrorWithWindowsPathSeparator(t *testing.T) {
 }
 
 func TestIsExecutable(t *testing.T) {
-	tempDir, removeTempDir := morerequire.RequireNewTempDir(t)
-	defer removeTempDir()
+	tempDir := t.TempDir()
 
 	bin := filepath.Join(tempDir, "envoy"+Exe)
 	require.NoError(t, os.WriteFile(bin, []byte{}, 0700))
@@ -57,8 +54,7 @@ func TestIsExecutable(t *testing.T) {
 }
 
 func TestIsExecutable_Not(t *testing.T) {
-	tempDir, removeTempDir := morerequire.RequireNewTempDir(t)
-	defer removeTempDir()
+	tempDir := t.TempDir()
 
 	bin := filepath.Join(tempDir, "foo.txt")
 	require.NoError(t, os.WriteFile(bin, []byte{}, 0600))

--- a/internal/tar/tar_test.go
+++ b/internal/tar/tar_test.go
@@ -27,7 +27,6 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/tetratelabs/func-e/internal/test/morerequire"
 	"github.com/tetratelabs/func-e/internal/version"
 )
 
@@ -104,8 +103,7 @@ func TestUntar(t *testing.T) {
 	}{{true, true}, {true, false}, {false, true}, {false, false}} {
 		tt := tt
 		t.Run(fmt.Sprintf("%+v", tt), func(t *testing.T) {
-			tempDir, removeTempDir := morerequire.RequireNewTempDir(t)
-			defer removeTempDir()
+			tempDir := t.TempDir()
 
 			dst := tempDir
 			if !tt.dstExists {
@@ -143,8 +141,7 @@ func TestUntarAndVerify(t *testing.T) {
 		file := k
 		sha256 := v
 		t.Run(file, func(t *testing.T) {
-			tempDir, removeTempDir := morerequire.RequireNewTempDir(t)
-			defer removeTempDir()
+			tempDir := t.TempDir()
 
 			f, err := os.Open(file)
 			require.NoError(t, err)
@@ -165,8 +162,7 @@ func (r errorReader) Read(_ []byte) (n int, err error) {
 }
 
 func TestUntarAndVerify_ErrorReading(t *testing.T) {
-	tempDir, removeTempDir := morerequire.RequireNewTempDir(t)
-	defer removeTempDir()
+	tempDir := t.TempDir()
 
 	expectedErr := errors.New("ice cream")
 	err := UntarAndVerify(tempDir, &errorReader{expectedErr}, "1234")
@@ -174,8 +170,7 @@ func TestUntarAndVerify_ErrorReading(t *testing.T) {
 }
 
 func TestUntarAndVerify_InvalidSignature(t *testing.T) {
-	tempDir, removeTempDir := morerequire.RequireNewTempDir(t)
-	defer removeTempDir()
+	tempDir := t.TempDir()
 
 	f, err := os.Open("testdata/empty.tar.xz")
 	require.NoError(t, err)
@@ -205,8 +200,7 @@ func requireEmptyDirectory(t *testing.T, dst string) {
 }
 
 func TestTarGZ(t *testing.T) {
-	tempDir, removeTempDir := morerequire.RequireNewTempDir(t)
-	defer removeTempDir()
+	tempDir := t.TempDir()
 
 	src := filepath.Join("testdata", "foo")
 	dst := filepath.Join(tempDir, "test.tar.gz")

--- a/internal/test/envoy.go
+++ b/internal/test/envoy.go
@@ -41,7 +41,7 @@ type Runner interface {
 }
 
 // RequireRun executes Run on the given Runtime and calls shutdown after it started.
-func RequireRun(t *testing.T, shutdown func(), r Runner, stderr io.Reader, args ...string) (err error) {
+func RequireRun(t *testing.T, shutdown func(), r Runner, stderr io.Reader, args ...string) error {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -52,6 +52,7 @@ func RequireRun(t *testing.T, shutdown func(), r Runner, stderr io.Reader, args 
 
 	// Run in a goroutine, and signal when that completes
 	ran := make(chan bool)
+	var err error
 	go func() {
 		if e := r.Run(ctx, args); e != nil && err == nil {
 			err = e // first error
@@ -74,7 +75,7 @@ func RequireRun(t *testing.T, shutdown func(), r Runner, stderr io.Reader, args 
 	// Even if we had an error, we invoke the shutdown at this point to avoid leaking a process
 	shutdown()
 	<-ran // block until the runner finished
-	return
+	return err
 }
 
 var (

--- a/internal/test/morerequire/morerequire.go
+++ b/internal/test/morerequire/morerequire.go
@@ -17,25 +17,12 @@
 package morerequire
 
 import (
-	"io/ioutil"
 	"os"
-	"path/filepath"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/require"
 )
-
-// RequireNewTempDir creates a new directory. The function returned cleans it up.
-func RequireNewTempDir(t *testing.T) (string, func()) {
-	d, err := ioutil.TempDir("", "")
-	require.NoError(t, err, `ioutil.TempDir("", "") erred`)
-	d, err = filepath.EvalSymlinks(d)
-	require.NoError(t, err, `filepath.EvalSymlinks(%s) erred`, d)
-	return d, func() {
-		os.RemoveAll(d) //nolint
-	}
-}
 
 // RequireSetMtime sets the mtime of the dir given a string formatted date. Ex "2006-01-02"
 func RequireSetMtime(t *testing.T, dir, date string) {
@@ -59,19 +46,16 @@ func RequireSetenv(t *testing.T, key, value string) func() {
 	}
 }
 
-// RequireChdirIntoTemp creates a new temp directory and cleans it up on with the returned function.
-func RequireChdirIntoTemp(t *testing.T) func() {
+// RequireChdir changes the working directory reverts it on the returned function
+func RequireChdir(t *testing.T, dir string) func() {
 	wd, err := os.Getwd()
 	require.NoError(t, err)
 
-	tempDir, removeTempDir := RequireNewTempDir(t)
-	if err = os.Chdir(tempDir); err != nil {
-		removeTempDir() // don't leak
+	if err = os.Chdir(dir); err != nil {
 		require.NoError(t, err)
 	}
 
 	return func() {
 		require.NoError(t, os.Chdir(wd))
-		removeTempDir()
 	}
 }

--- a/internal/test/server.go
+++ b/internal/test/server.go
@@ -33,7 +33,6 @@ import (
 	"github.com/tetratelabs/func-e/internal/globals"
 	"github.com/tetratelabs/func-e/internal/moreos"
 	"github.com/tetratelabs/func-e/internal/tar"
-	"github.com/tetratelabs/func-e/internal/test/morerequire"
 	"github.com/tetratelabs/func-e/internal/version"
 )
 
@@ -113,8 +112,7 @@ func (s *server) funcEVersions() []byte {
 
 // RequireFakeEnvoyTarGz makes a fake envoy.tar.gz
 func RequireFakeEnvoyTarGz(t *testing.T, v version.Version) ([]byte, version.SHA256Sum) {
-	tempDir, removeTempDir := morerequire.RequireNewTempDir(t)
-	defer removeTempDir()
+	tempDir := t.TempDir()
 
 	// construct the platform directory based on the input version
 	installDir := filepath.Join(tempDir, string(v))


### PR DESCRIPTION
Some tests passed for the wrong reason because of drift in CLI parsing
inside the fake envoy server. This fixes that and also moves the fake
admin endpoint into the fake envoy server. This allows us to verify
admin address path parsing works as we expect it to.