### PR TITLE
Pares down code to work around flake

### DIFF
--- a/internal/envoy/runtime.go
+++ b/internal/envoy/runtime.go
@@ -60,19 +60,6 @@ type Runtime struct {
 
 // String is only used in tests. It is slow, but helps when debugging CI failures
 func (r *Runtime) String() string {
-	var stdout, stderr string
-	if r.OutFile != nil {
-		if b, err := os.ReadFile(r.OutFile.Name()); err == nil {
-			stdout = string(b)
-		}
-	}
-
-	if r.ErrFile != nil {
-		if b, err := os.ReadFile(r.ErrFile.Name()); err == nil {
-			stderr = string(b)
-		}
-	}
-
 	exitStatus := -1
 	if r.cmd != nil && r.cmd.ProcessState != nil {
 		if ws, ok := r.cmd.ProcessState.Sys().(syscall.WaitStatus); ok {
@@ -80,7 +67,7 @@ func (r *Runtime) String() string {
 		}
 	}
 
-	return fmt.Sprintf("{stdout: %s, stderr: %s, exitStatus: %d}", stdout, stderr, exitStatus)
+	return fmt.Sprintf("{exitStatus: %d}", exitStatus)
 }
 
 // GetRunDir returns the run-specific directory files can be written to.

--- a/internal/envoy/runtime_test.go
+++ b/internal/envoy/runtime_test.go
@@ -15,7 +15,6 @@
 package envoy
 
 import (
-	"os"
 	"os/exec"
 	"path/filepath"
 	"testing"
@@ -123,23 +122,6 @@ func TestString(t *testing.T) {
 	require.NoError(t, cmdRunning.cmd.Start())
 	defer cmdRunning.cmd.Process.Kill() //nolint
 
-	tmpDir := t.TempDir()
-	files := NewRuntime(&globals.RunOpts{})
-
-	stdoutLog, err := os.OpenFile(filepath.Join(tmpDir, "stdout.log"), os.O_CREATE|os.O_WRONLY, 0600)
-	require.NoError(t, err)
-	defer stdoutLog.Close()
-	files.OutFile = stdoutLog
-	stdoutLog.Write([]byte("foo")) //nolint
-	stdoutLog.Sync()               //nolint
-
-	stderrLog, err := os.OpenFile(filepath.Join(tmpDir, "stderr.log"), os.O_CREATE|os.O_WRONLY, 0600)
-	require.NoError(t, err)
-	defer stderrLog.Close()
-	files.ErrFile = stderrLog
-	stderrLog.Write([]byte("bar")) //nolint
-	stderrLog.Sync()               //nolint
-
 	tests := []struct {
 		name     string
 		runtime  *Runtime
@@ -148,22 +130,17 @@ func TestString(t *testing.T) {
 		{
 			name:     "command exited",
 			runtime:  cmdExited,
-			expected: "{stdout: , stderr: , exitStatus: 0}",
+			expected: "{exitStatus: 0}",
 		},
 		{
 			name:     "command failed",
 			runtime:  cmdFailed,
-			expected: "{stdout: , stderr: , exitStatus: 1}",
+			expected: "{exitStatus: 1}",
 		},
 		{
 			name:     "command running",
 			runtime:  cmdRunning,
-			expected: "{stdout: , stderr: , exitStatus: -1}",
-		},
-		{
-			name:     "console files exist",
-			runtime:  files,
-			expected: "{stdout: foo, stderr: bar, exitStatus: -1}",
+			expected: "{exitStatus: -1}",
 		},
 	}
 


### PR DESCRIPTION
As the flake isn't OS-specific (failed on linux, too), I changed the code to be more lenient. I also removed most of the code around Runtime.String() as it didn't help in debugging.