### PR TITLE
Generates release assets without goreleaser on 'make dist'

### DIFF
--- a/.github/workflows/msi.yaml
+++ b/.github/workflows/msi.yaml
@@ -15,12 +15,14 @@ on:
       - 'packaging/msi/*'
       - 'packaging/icon@48w.ico'
       - '.github/workflows/msi.yaml'
+      - 'Next.mk'
   pull_request:  # We also run tests on pull requests targeted at the master branch
     branches: master
     paths:
       - 'packaging/msi/*'
       - 'packaging/icon@48w.ico'
       - '.github/workflows/msi.yaml'
+      - 'Next.mk'
   # workflow_dispatch will let us manually trigger the workflow from GitHub actions dashboard.
   # For example, you can try to build a branch without raising a pull request.
   # See https://docs.github.com/en/free-pro-team@latest/actions/managing-workflow-runs/manually-running-a-workflow
@@ -48,10 +50,10 @@ jobs:
           - os: windows-latest
             setup: |
               echo "$WIX\\bin" >> $GITHUB_PATH
-              osslsigncode_version=2.1
+              osslsigncode_version=2.2
               gh release download -R mtrojnar/osslsigncode ${osslsigncode_version} -p '*windows.zip'
-              unzip -qq *.zip -d ${HOME} && rm *.zip
-              echo "${HOME}\\osslsigncode_${osslsigncode_version}_windows" >> $GITHUB_PATH
+              unzip -qq *.zip -d ${HOME}/osslsigncode && rm *.zip
+              echo "${HOME}\\osslsigncode" >> $GITHUB_PATH
 
     steps:
       - name: "Setup msitools, wixtoolset, osslsigncode"
@@ -77,7 +79,7 @@ jobs:
           restore-keys: test-${{ runner.os }}-${{ env.GO_VERSION }}-go-
 
       - name: "Build Windows Installer (MSI)"
-        run: make msi
+        run: make -f Next.mk dist
 
       # This only checks the installer when built on Windows as it is simpler than switching OS.
       # refreshenv is from choco, and lets you reload ENV variables (used here for PATH).

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /.idea
 /coverage.txt
+/build/
 /dist/
 
 # intermediate files used to create Windows Installer (func-e.msi)

--- a/Next.mk
+++ b/Next.mk
@@ -109,7 +109,7 @@ $(checksums): $(archives) $(packages)
 
 # dist generates the assets that attach to a release
 # Ex. https://github.com/tetratelabs/func-e/releases/tag/v$(VERSION)
-dist: $(archives) $(archives) $(packages) $(checksums) ## generates release assets
+dist: $(archives) $(packages) $(checksums) ## generates release assets
 
 # this makes a marker file ending in .signed to avoid repeatedly calling codesign
 %.signed: %

--- a/Next.mk
+++ b/Next.mk
@@ -1,18 +1,20 @@
 # Copyright 2021 Tetrate
 # Licensed under the Apache License, Version 2.0 (the "License")
-.PHONY: test build e2e
+#
+# This script uses automatic variables (ex $<) and substitution references $(<:.signed=)
+# Please see GNU make's documentation if unfamiliar: https://www.gnu.org/software/make/manual/html_node/
+.PHONY: test build e2e dist
 
 # This should be driven by automation and result in N.N.N, not vN.N.N
-VERSION ?= dev
+VERSION   ?= dev
+build_dir := build
+dist_dir  := dist
 
-# Temporarily match convention of where goreleaser put binaries
-build_dir         := dist
 # Build the path relating to the current runtime (goos,goarch)
-current_binary    := $(build_dir)/func-e_$(shell go env GOOS)_$(shell go env GOARCH)/func-e$(shell go env GOEXE)
-# Right now, the only arch we support is amd64 because Envoy doesn't yet support arm64 on Windows
-# https://github.com/envoyproxy/envoy/issues/17572
-# Once that occurs, we will need to set -arch arm64 and bundle accordingly.
-windows_binary    := $(build_dir)/func-e_windows_amd64/func-e.exe
+goos   := $(shell go env GOOS)
+goarch := $(shell go env GOARCH)
+goexe  := $(shell go env GOEXE)
+current_binary := $(build_dir)/func-e_$(goos)_$(goarch)/func-e$(goexe)
 
 # ANSI escape codes. f_ means foreground, b_ background.
 # See https://en.wikipedia.org/wiki/ANSI_escape_code#SGR_(Select_Graphic_Rendition)_parameters
@@ -37,32 +39,110 @@ build: $(current_binary) ## Build the func-e binary
 test: ## Run all unit tests
 	@printf "$(ansi_format_dark)" test "running unit tests"
 	@go test . ./internal/...
-	@printf "$(ansi_format_bright)" test "✔"
+	@printf "$(ansi_format_bright)" test "ok"
 
 # Tests run one at a time, in verbose mode, so that failures are easy to diagnose.
 # Note: -failfast helps as it stops at the first error. However, it is not a cacheable flag, so runs won't cache.
 e2e: $(current_binary) ## Run all end-to-end tests
 	@printf "$(ansi_format_dark)" e2e "running end-to-end tests"
 	@E2E_FUNC_E_PATH=$(dir $(current_binary)) go test -parallel 1 -v -failfast ./e2e
-	@printf "$(ansi_format_bright)" e2e "✔"
+	@printf "$(ansi_format_bright)" e2e "ok"
 
-# Use patterns to set appropriate variables needed for multi-platform builds
-$(build_dir)/func-e_darwin_%/func-e: override goos=darwin
-$(build_dir)/func-e_linux_%/func-e: override goos=linux
-$(build_dir)/func-e_%_amd64/func-e: override goarch=amd64
-$(build_dir)/func-e_%_arm64/func-e: override goarch=arm64
-$(build_dir)/func-e_%/func-e:
-	$(call go-build, $@)
+non_windows_platforms := darwin_amd64 darwin_arm64 linux_amd64 linux_arm64
+# TODO: arm64 on Windows https://github.com/envoyproxy/envoy/issues/17572
+windows_platforms := windows_amd64
 
-$(windows_binary): override goos=windows
-$(windows_binary): override goarch=amd64
-$(windows_binary):
-	$(call go-build, $@)
+$(build_dir)/func-e_%/func-e: main.go
+	$(call go-build, $@, $^)
 
+$(dist_dir)/func-e_$(VERSION)_%.tar.gz: $(build_dir)/func-e_%/func-e
+	@printf "$(ansi_format_dark)" tar.gz "tarring $@"
+	@mkdir -p $(dir $@)
+	@tar --strip-components 2 -cpzf $@ $<
+	@printf "$(ansi_format_bright)" tar.gz "ok"
+
+$(build_dir)/func-e_%/func-e.exe: main.go
+	$(call go-build, $@, $^)
+
+$(dist_dir)/func-e_$(VERSION)_%.zip: $(build_dir)/func-e_%/func-e.exe.signed
+	@printf "$(ansi_format_dark)" zip "zipping $@"
+	@mkdir -p $(dir $@)
+ifeq ($(goos),windows)  # Windows 10 etc use 7zip
+	@# '-bso0 -bsp0' makes it quiet, except errors
+	@# Wildcards in 7zip will skip the directory. We single-quote to ensure they aren't interpreted by the shell.
+	@7z -bso0 -bsp0 a $@ './$(dir $<)/*.exe'
+else  # Otherwise, assume zip is available
+	@zip -qj $@ $(<:.signed=)
+endif
+	@printf "$(ansi_format_bright)" zip "ok"
+
+# msi-arch is a macro so we can detect it based on the file naming convention
+msi-arch = $(if $(findstring amd64,$1),x64,arm64)
+# Default to a dummy version, which is always lower than a real release
+msi_version=$(VERSION:dev=0.0.1)
+
+# This builds the Windows installer (MSI) using platform-dependent WIX commands.
+$(dist_dir)/func-e_$(VERSION)_%.msi: $(build_dir)/func-e_%/func-e.exe.signed
+	@printf "$(ansi_format_dark)" msi "building $@"
+	@mkdir -p $(dir $@)
+ifeq ($(goos),windows)  # Windows 10 etc use https://wixtoolset.org
+	@candle -nologo -arch $(call msi-arch,$@) -dVersion=$(msi_version) -dBin=$(<:.signed=) packaging/msi/func-e.wxs
+	@light -nologo func-e.wixobj -o $@ -spdb
+	@rm func-e.wixobj
+else  # use https://wiki.gnome.org/msitools
+	@wixl -a $(call msi-arch,$@) -D Version=$(msi_version) -D Bin=$(<:.signed=) -o $@ packaging/msi/func-e.wxs
+endif
+	$(call codesign, $@)
+	@printf "$(ansi_format_bright)" msi "ok"
+
+# Archives are tar.gz, except in the case of Windows, which uses zip.
+archives  := $(non_windows_platforms:%=$(dist_dir)/func-e_$(VERSION)_%.tar.gz) $(windows_platforms:%=$(dist_dir)/func-e_$(VERSION)_%.zip)
+packages  := $(windows_platforms:%=$(dist_dir)/func-e_$(VERSION)_%.msi)
+checksums := $(dist_dir)/func-e_$(VERSION)_checksums.txt
+
+# Darwin doesn't have sha256sum. See https://github.com/actions/virtual-environments/issues/90
+sha256sum := $(if $(findstring darwin,$(goos)),shasum -a 256,sha256sum)
+$(checksums): $(archives) $(packages)
+	@printf "$(ansi_format_dark)" sha256sum "generating $@"
+	@$(sha256sum) $^ > $@
+	@printf "$(ansi_format_bright)" sha256sum "ok"
+
+# dist generates the assets that attach to a release
+# Ex. https://github.com/tetratelabs/func-e/releases/tag/v$(VERSION)
+dist: $(archives) $(archives) $(packages) $(checksums) ## generates release assets
+
+# this makes a marker file ending in .signed to avoid repeatedly calling codesign
+%.signed: %
+	$(call codesign, $<)
+	@echo > $@
+
+# define macros for multi-platform builds. these parse the filename being built
+go-arch = $(if $(findstring amd64,$1),amd64,arm64)
+go-os   = $(if $(findstring .exe,$1),windows,$(if $(findstring linux,$1),linux,darwin))
 define go-build
 	@printf "$(ansi_format_dark)" build "building $1"
-	@CGO_ENABLED=0 GOOS=$(goos) GOARCH=$(goarch) go build \
+	@CGO_ENABLED=0 GOOS=$(call go-os,$1) GOARCH=$(call go-arch,$1) go build \
 		-ldflags "-s -w -X main.version=$(VERSION)" \
-		-o $1 main.go
-	@printf "$(ansi_format_bright)" build "✔"
+		-o $1 $2
+	@printf "$(ansi_format_bright)" build "ok"
+endef
+
+# This requires osslsigncode package (apt or brew) or latest windows release from mtrojnar/osslsigncode
+#
+# Default is self-signed while production should be a Digicert signing key
+#
+# Ex.
+# ```bash
+# keytool -genkey -alias func-e -storetype PKCS12 -keyalg RSA -keysize 2048 -storepass func-e-bunch \
+# -keystore func-e.p12 -dname "O=func-e,CN=func-e.io" -validity 3650
+# ```
+WINDOWS_CODESIGN_P12 ?= packaging/msi/func-e.p12
+WINDOWS_CODESIGN_PASSWORD ?= func-e-bunch
+define codesign
+	@printf "$(ansi_format_dark)" codesign "signing $1"
+	@osslsigncode sign -h sha256 -pkcs12 ${WINDOWS_CODESIGN_P12} -pass "${WINDOWS_CODESIGN_PASSWORD}" \
+	-n "func-e makes running Envoy® easy" -i https://func-e.io -t http://timestamp.digicert.com \
+	$(if $(findstring msi,$(1)),-add-msi-dse) -in $1 -out $1-signed
+	@mv $1-signed $1
+	@printf "$(ansi_format_bright)" codesign "ok"
 endef

--- a/packaging/msi/verify_msi.cmd
+++ b/packaging/msi/verify_msi.cmd
@@ -15,7 +15,7 @@
 :: verify_msi is written in cmd because msiexec doesn't agree with git-bash
 :: See https://github.com/git-for-windows/git/issues/2526
 @echo off
-if not defined MSI_FILE set MSI_FILE=dist\func-e_windows_amd64\func-e.msi
+if not defined MSI_FILE set MSI_FILE=dist\func-e_dev_windows_amd64.msi
 echo installing %MSI_FILE%
 msiexec /i %MSI_FILE% /qn || exit /b 1
 

--- a/packaging/msi/winget_manifest.sh
+++ b/packaging/msi/winget_manifest.sh
@@ -23,7 +23,7 @@
 # winget validate --manifest ${manifest_path}
 
 version=${1:-0.0.1}
-msi_file=${2:-dist/func-e_windows_amd64/func-e.msi}
+msi_file=${2:-dist/func-e_dev_windows_amd64.msi}
 
 case $(uname -s) in
 CYGWIN* | MSYS* | MINGW*)


### PR DESCRIPTION
This removes the dependency on goreleaser by implementing what it does
in make.

This will fix #352 once the release process uses it, which will be a
different PR.

<img width="643" alt="Screen Shot 2021-08-29 at 2 19 17 PM" src="https://user-images.githubusercontent.com/64215/131238263-54a3a483-81c2-45c6-894c-3facee6ff382.png">

```bash
± |make-dist {3} ✓| → file dist/*
dist/func-e_dev_checksums.txt:       ASCII text
dist/func-e_dev_darwin_amd64.tar.gz: gzip compressed data, last modified: Sun Aug 29 04:19:00 2021, from Unix, original size modulo 2^32 7503360
dist/func-e_dev_darwin_arm64.tar.gz: gzip compressed data, last modified: Sun Aug 29 04:19:01 2021, from Unix, original size modulo 2^32 7743488
dist/func-e_dev_linux_amd64.tar.gz:  gzip compressed data, last modified: Sun Aug 29 04:19:01 2021, from Unix, original size modulo 2^32 7005696
dist/func-e_dev_linux_arm64.tar.gz:  gzip compressed data, last modified: Sun Aug 29 04:19:02 2021, from Unix, original size modulo 2^32 6948352
dist/func-e_dev_windows_amd64.msi:   Composite Document File V2 Document, Little Endian, Os: Windows, Version 5.0, MSI Installer, Code page: 1252, Title: Installation Database, Subject: func-e installer, Author: Tetrate, Keywords: Installer, Comments: This installer database contains the logic and data required to install func-e., Template: x64;1033, Revision Number: {D3FEA555-CCBD-4DCF-9FE3-55E05B7C63ED}, Create Time/Date: Sun Aug 29 04:19:04 2021, Last Saved Time/Date: Sun Aug 29 04:19:04 2021, Number of Pages: 310, Number of Words: 2, Name of Creating Application: msitools 0.101, Security: 2
dist/func-e_dev_windows_amd64.zip:   Zip archive data, at least v2.0 to extract
```