### PR TITLE
Adds release notes generation script

### DIFF
--- a/.github/workflows/release_notes.sh
+++ b/.github/workflows/release_notes.sh
@@ -1,0 +1,41 @@
+#!/bin/sh -ue
+#
+# This script generates the release notes "func-e" for a specific release tag.
+# .github/release_notes.sh v0.3.0
+
+tag=$1
+prior_tag=$(git tag -l 'v*'|sed "/${tag}/,+10d"|tail -1)
+range="${prior_tag}..${tag}"
+
+git config log.mailmap true
+changelog=$(git log --format='%h %s %aN, %(trailers:key=co-authored-by)' "${range}")
+contributors=$(git shortlog -s --group=author --group=trailer:co-authored-by "${range}" | cut -f 2)
+
+# strip the v off the tag name more shell portable than ${tag:1}
+version=$(echo "${tag}" | cut -c2-100) || exit 1
+cat <<EOF
+func-e ${version} supports X and Y and notably fixes Z
+
+TODO: classify the below into up to 4 major headings and the rest as bulleted items in minor changes
+The published release notes should only include the summary statement in this section.
+
+${changelog}
+
+## X packages
+
+Don't forget to cite who was involved and why
+
+## func-e Y
+
+## Minor changes
+
+TODO: don't add trivial things like fixing spaces or non-concerns like build glitches
+
+* Z is now fixed thanks to Yogi Bear
+
+## Thank you
+func-e ${version} was possible thanks to the following contributors:
+
+${contributors}
+
+EOF

--- a/.github/workflows/release_notes.sh
+++ b/.github/workflows/release_notes.sh
@@ -9,7 +9,7 @@ range="${prior_tag}..${tag}"
 
 git config log.mailmap true
 changelog=$(git log --format='%h %s %aN, %(trailers:key=co-authored-by)' "${range}")
-contributors=$(git shortlog -s --group=author --group=trailer:co-authored-by "${range}" | cut -f 2)
+contributors=$(git shortlog -s --group=author --group=trailer:co-authored-by "${range}" | cut -f 2 |sort)
 
 # strip the v off the tag name more shell portable than ${tag:1}
 version=$(echo "${tag}" | cut -c2-100) || exit 1

--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,2 @@
+Adrian Cole <adrian@tetrate.io>
+Adrian Cole <64215+codefromthecrypt@users.noreply.github.com>


### PR DESCRIPTION
This will be used in the new release process to generate draft release
notes that a person edits before clicking publish.

Notably, this correctly annotates co-authors, which is a common practice
in func-e, but easy to miss.

Ex. (nevermind the 'aster' as I'm hacking this to show pending notes)
```bash
$ .github/workflows/release_notes.sh master
```

---
---

func-e aster supports X and Y and notably fixes Z

TODO: classify the below into up to 4 major headings and the rest as bulleted items in minor changes
The published release notes should only include the summary statement in this section.

ee700a1 Converts e2e to new Makefile (#356) Adrian Cole, Co-authored-by: Dhi Aurrahman <dio@rockybars.com>

83e7c30 updates last known Envoy to 1.19.1 (#355) Adrian Cole, 
f975609 Aligns make to func-e color scheme (#354) Adrian Cole, 
551840f Scaffold a new Makefile (#353) Adrian Cole, 
877a72e Removes bingo for `go run` (#350) Adrian Cole, Co-authored-by: Takeshi Yoneda <takeshi@tetrate.io>

12a74b1 Adds vanity downloads (#351) Adrian Cole, 
0f313c8 Pares down code to work around flake (#349) Adrian Cole, 
e74c0b7 Removes test utilities for built-ins (#347) Adrian Cole, 
41c2742 Cleans up tests (#348) Adrian Cole, 
17375b4 Updates to Go 1.17 (#346) Adrian Cole, 
6ae5d48 Corrects manifest path Adrian Cole, 
a9ccc4d fixes auth Adrian Cole, 
a4bc290 Fixes glitches in package update script (#344) Adrian Cole, 

## X packages

Don't forget to cite who was involved and why

## func-e Y

## Minor changes

TODO: don't add trivial things like fixing spaces or non-concerns like build glitches

* Z is now fixed thanks to Yogi Bear

## Thank you
func-e aster was possible thanks to the following contributors:

Adrian Cole
Dhi Aurrahman
Takeshi Yoneda

