### PR TITLE
Allow to "use" minor versions

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -4,7 +4,8 @@ downloads and installs the latest version of Envoy for you.
 
 To list versions of Envoy you can use, execute `func-e versions -a`. To
 choose one, invoke `func-e use 1.19.1`. This installs into
-`$FUNC_E_HOME/versions/1.19.1`, if not already present.
+`$FUNC_E_HOME/versions/1.19.1`, if not already present. You may also use
+minor version, such as `func-e use 1.19`.
 
 You may want to override `$ENVOY_VERSIONS_URL` to supply custom builds or
 otherwise control the source of Envoy binaries. When overriding, validate

--- a/e2e/func-e_use_test.go
+++ b/e2e/func-e_use_test.go
@@ -161,7 +161,7 @@ func getVersionsRange(stdout, minor string) (max, min string) {
 			rows = append(rows, row[:strings.Index(row, " ")])
 		}
 	}
-	min = rows[0]
-	max = rows[1]
+	min = rows[len(rows)-2]
+	max = rows[len(rows)-1]
 	return
 }

--- a/e2e/func-e_use_test.go
+++ b/e2e/func-e_use_test.go
@@ -82,8 +82,6 @@ func TestFuncEUse_MinorVersion(t *testing.T) {
 	// The upgraded version.
 	upgradedVersion := version.Version(upgraded)
 
-	fmt.Println()
-
 	homeDir := t.TempDir()
 
 	t.Run("install last known", func(t *testing.T) {

--- a/e2e/func-e_use_test.go
+++ b/e2e/func-e_use_test.go
@@ -69,6 +69,16 @@ func TestFuncEUse_UnknownVersion(t *testing.T) {
 `, v, runtime.GOOS, runtime.GOARCH), stderr)
 }
 
+func TestFuncEUse_UnknownMinorVersion(t *testing.T) {
+	v := "1.1"
+	stdout, stderr, err := funcEExec("use", v)
+
+	require.EqualError(t, err, "exit status 1")
+	require.Empty(t, stdout)
+	require.Equal(t, moreos.Sprintf(`error: couldn't find the latest patch for "%s" for platform "%s/%s"
+`, v, runtime.GOOS, runtime.GOARCH), stderr)
+}
+
 func TestFuncEUse_MinorVersion(t *testing.T) {
 	// The intended minor version to be installed. This version is known to have darwin, linux, and windows binaries.
 	minorVersion := version.Version("1.18")
@@ -151,8 +161,8 @@ func TestFuncEUse_MinorVersion(t *testing.T) {
 	})
 }
 
-// getVersionsRange returns the latest patch of a minor version and the one before it.
-func getVersionsRange(stdout, minor string) (max, min string) {
+// getVersionsRange returns the first and latest patch of a minor version.
+func getVersionsRange(stdout, minor string) (first, latest string) {
 	s := bufio.NewScanner(strings.NewReader(stdout))
 	rows := []string{}
 	for s.Scan() {
@@ -161,7 +171,8 @@ func getVersionsRange(stdout, minor string) (max, min string) {
 			rows = append(rows, row[:strings.Index(row, " ")])
 		}
 	}
-	min = rows[len(rows)-2]
-	max = rows[len(rows)-1]
+	// The rows is sorted in descending order.
+	first = rows[len(rows)-1]
+	latest = rows[0]
 	return
 }

--- a/e2e/func-e_use_test.go
+++ b/e2e/func-e_use_test.go
@@ -67,6 +67,13 @@ func TestFuncEUse_UnknownVersion(t *testing.T) {
 }
 
 func TestFuncEUse_MinorVersion(t *testing.T) {
+	// The initial version.
+	baseVersion := version.Version("1.18.3")
+	// The intended minor version to be installed.
+	minorVersion := version.Version("1.18")
+	// The upgraded version.
+	upgradedVersion := version.Version("1.18.4")
+
 	homeDir := t.TempDir()
 
 	t.Run("install last known", func(t *testing.T) {
@@ -86,7 +93,6 @@ func TestFuncEUse_MinorVersion(t *testing.T) {
 		require.Equal(t, version.LastKnownEnvoy, version.Version(f))
 	})
 
-	baseVersion := version.Version("1.12.0")
 	t.Run("install base version", func(t *testing.T) {
 		stdout, stderr, err := funcEExec("--home-dir", homeDir, "use", string(baseVersion))
 
@@ -104,11 +110,6 @@ func TestFuncEUse_MinorVersion(t *testing.T) {
 		require.Equal(t, baseVersion, version.Version(f))
 	})
 
-	// The intended minor version to be installed.
-	minorVersion := version.Version("1.12")
-
-	// This version is EOL'd based on: https://github.com/envoyproxy/envoy/blob/main/RELEASES.md#release-schedule.
-	upgradedVersion := version.Version("1.12.7")
 	t.Run("install upgraded version", func(t *testing.T) {
 		stdout, stderr, err := funcEExec("--home-dir", homeDir, "use", string(minorVersion))
 

--- a/internal/cmd/app.go
+++ b/internal/cmd/app.go
@@ -89,6 +89,7 @@ func NewApp(o *globals.GlobalOpts) *cli.App {
 		if err := setEnvoyVersionsURL(o, envoyVersionsURL); err != nil {
 			return err
 		}
+		// The o.FuncEVersions may be initialized before this, and that can only happen in tests.
 		if o.FuncEVersions == nil {
 			o.FuncEVersions = envoy.NewFuncEVersions(o.EnvoyVersionsURL, o.Platform, o.Version)
 		}

--- a/internal/cmd/app.go
+++ b/internal/cmd/app.go
@@ -89,7 +89,9 @@ func NewApp(o *globals.GlobalOpts) *cli.App {
 		if err := setEnvoyVersionsURL(o, envoyVersionsURL); err != nil {
 			return err
 		}
-		o.FuncEVersions = envoy.NewFuncEVersions(o.EnvoyVersionsURL, o.Platform, o.Version)
+		if o.FuncEVersions == nil {
+			o.FuncEVersions = envoy.NewFuncEVersions(o.EnvoyVersionsURL, o.Platform, o.Version)
+		}
 		return nil
 	}
 

--- a/internal/cmd/app.go
+++ b/internal/cmd/app.go
@@ -35,6 +35,7 @@ import (
 func NewApp(o *globals.GlobalOpts) *cli.App {
 	var envoyVersionsURL, homeDir, platform string
 	lastKnownEnvoy := getLastKnownEnvoy(o)
+	lastKnownMinorVersionEnvoy := lastKnownEnvoy[:strings.LastIndex(string(lastKnownEnvoy), ".")]
 	lastKnownEnvoyPath := moreos.ReplacePathSeparator(fmt.Sprintf("`$FUNC_E_HOME/versions/%s`", lastKnownEnvoy))
 
 	app := cli.NewApp()
@@ -48,7 +49,8 @@ func NewApp(o *globals.GlobalOpts) *cli.App {
 
    To list versions of Envoy you can use, execute ` + "`func-e versions -a`" + `. To
    choose one, invoke ` + fmt.Sprintf("`func-e use %s`", lastKnownEnvoy) + `. This installs into
-   ` + lastKnownEnvoyPath + `, if not already present.
+   ` + lastKnownEnvoyPath + `, if not already present. You may also use
+   minor version, such as ` + fmt.Sprintf("`func-e use %s`", lastKnownMinorVersionEnvoy) + `.
 
    You may want to override ` + "`$ENVOY_VERSIONS_URL`" + ` to supply custom builds or
    otherwise control the source of Envoy binaries. When overriding, validate

--- a/internal/cmd/app.go
+++ b/internal/cmd/app.go
@@ -92,7 +92,7 @@ func NewApp(o *globals.GlobalOpts) *cli.App {
 			return err
 		}
 		// The o.FuncEVersions may be initialized before this, and that can only happen in tests.
-		if o.FuncEVersions == nil {
+		if o.FuncEVersions == nil { // not overridden for tests
 			o.FuncEVersions = envoy.NewFuncEVersions(o.EnvoyVersionsURL, o.Platform, o.Version)
 		}
 		return nil

--- a/internal/cmd/run.go
+++ b/internal/cmd/run.go
@@ -156,7 +156,7 @@ func ensureEnvoyVersion(c *cli.Context, o *globals.GlobalOpts) error {
 				if latest, err = getLatestInstalledPatch(o, v); err != nil {
 					return err
 				}
-				o.Logf("couldn't check the latest patch for %q for platform %q using %q instead\n", v, o.Platform, latest)
+				o.Logf("couldn't check the latest patch for %q for platform %q, using the latest installed version %q\n", v, o.Platform, latest)
 			}
 			o.EnvoyVersion = latest
 		}

--- a/internal/cmd/run.go
+++ b/internal/cmd/run.go
@@ -149,6 +149,17 @@ func ensureEnvoyVersion(c *cli.Context, o *globals.GlobalOpts) error {
 			return NewValidationError(err.Error())
 		}
 		o.EnvoyVersion = v
+		if matched := globals.EnvoyStrictMinorVersionPattern.MatchString(string(v)); matched {
+			var err error
+			var latest version.Version
+			if latest, err = o.FuncEVersions.FindLatestPatch(c.Context, v); err != nil {
+				if latest, err = getLatestInstalledPatch(o, v); err != nil {
+					return err
+				}
+				o.Logf("couldn't check the latest patch for %q for platform %q using %q instead\n", v, o.Platform, latest)
+			}
+			o.EnvoyVersion = latest
+		}
 	}
 	return nil
 }

--- a/internal/cmd/testdata/func-e_help.txt
+++ b/internal/cmd/testdata/func-e_help.txt
@@ -7,7 +7,8 @@ USAGE:
 
    To list versions of Envoy you can use, execute `func-e versions -a`. To
    choose one, invoke `func-e use 1.99.0`. This installs into
-   `$FUNC_E_HOME/versions/1.99.0`, if not already present.
+   `$FUNC_E_HOME/versions/1.99.0`, if not already present. You may also use
+   minor version, such as `func-e use 1.99`.
 
    You may want to override `$ENVOY_VERSIONS_URL` to supply custom builds or
    otherwise control the source of Envoy binaries. When overriding, validate

--- a/internal/cmd/testdata/func-e_use_help.txt
+++ b/internal/cmd/testdata/func-e_use_help.txt
@@ -7,10 +7,13 @@ USAGE:
 DESCRIPTION:
    The '[version]' is from the "versions -a" command.
    The Envoy [version] installs on-demand into $FUNC_E_HOME/versions/[version]
-   if needed.
+   if needed. You may also exclude the patch component of the [version]
+   to use the latest patch version or to download the binary if it is
+   not already downloaded.
    
    This updates $PWD/.envoy-version or $FUNC_E_HOME/version with [version],
    depending on which is present.
    
    Example:
    $ func-e use 1.99.0
+   $ func-e use 1.99

--- a/internal/cmd/use.go
+++ b/internal/cmd/use.go
@@ -40,13 +40,16 @@ func NewUseCmd(o *globals.GlobalOpts) *cli.Command {
 		ArgsUsage: "[version]",
 		Description: moreos.Sprintf(`The '[version]' is from the "versions -a" command.
 The Envoy [version] installs on-demand into `+versionsDir+`[version]
-if needed.
+if needed. You may also exclude the patch component of the [version]
+to use the latest patch version or to download the binary if it is
+not already downloaded.
 
 This updates %s or %s with [version],
 depending on which is present.
 
 Example:
-$ func-e use %s`, currentVersionWorkingDirFile, currentVersionHomeDirFile, lastKnownEnvoy),
+$ func-e use %s
+$ func-e use %s`, currentVersionWorkingDirFile, currentVersionHomeDirFile, lastKnownEnvoy, lastKnownEnvoy[:strings.LastIndex(string(lastKnownEnvoy), ".")]),
 		Before: validateVersionArg,
 		Action: func(c *cli.Context) error {
 			v := version.Version(c.Args().First())

--- a/internal/cmd/use.go
+++ b/internal/cmd/use.go
@@ -51,7 +51,9 @@ Example:
 $ func-e use %s
 $ func-e use %s`, currentVersionWorkingDirFile, currentVersionHomeDirFile, lastKnownEnvoy,
 			lastKnownEnvoy[:strings.LastIndex(string(lastKnownEnvoy), ".")]),
-		Before: validateVersionArg,
+		Before: func(c *cli.Context) error {
+			return validateVersionArg(c, o)
+		},
 		Action: func(c *cli.Context) error {
 			v := version.Version(c.Args().First())
 			latest := v
@@ -73,14 +75,15 @@ $ func-e use %s`, currentVersionWorkingDirFile, currentVersionHomeDirFile, lastK
 	}
 }
 
-func validateVersionArg(c *cli.Context) error {
+func validateVersionArg(c *cli.Context, o *globals.GlobalOpts) error {
 	if c.NArg() == 0 {
 		return NewValidationError("missing [version] argument")
 	}
 	v := c.Args().First()
 	if matched := globals.EnvoyMinorVersionPattern.MatchString(v); !matched {
-		return NewValidationError("invalid [version] argument: %q should look like %q or %q", v, version.LastKnownEnvoy,
-			version.LastKnownMinorVersionEnvoy)
+		lastKnownEnvoy := getLastKnownEnvoy(o)
+		return NewValidationError("invalid [version] argument: %q should look like %q or %q", v, lastKnownEnvoy,
+			lastKnownEnvoy[:strings.LastIndex(string(lastKnownEnvoy), ".")])
 	}
 	return nil
 }

--- a/internal/cmd/use.go
+++ b/internal/cmd/use.go
@@ -96,8 +96,9 @@ func getLatestInstalledPatch(o *globals.GlobalOpts, minorVersion version.Version
 		}
 		return rows[i].releaseDate > rows[j].releaseDate
 	})
+	prefix := string(minorVersion) + "."
 	for i := range rows {
-		if strings.HasPrefix(string(rows[i].version), string(minorVersion)+".") {
+		if strings.HasPrefix(string(rows[i].version), prefix) {
 			return rows[i].version, nil
 		}
 	}

--- a/internal/cmd/use.go
+++ b/internal/cmd/use.go
@@ -49,7 +49,8 @@ depending on which is present.
 
 Example:
 $ func-e use %s
-$ func-e use %s`, currentVersionWorkingDirFile, currentVersionHomeDirFile, lastKnownEnvoy, lastKnownEnvoy[:strings.LastIndex(string(lastKnownEnvoy), ".")]),
+$ func-e use %s`, currentVersionWorkingDirFile, currentVersionHomeDirFile, lastKnownEnvoy,
+			lastKnownEnvoy[:strings.LastIndex(string(lastKnownEnvoy), ".")]),
 		Before: validateVersionArg,
 		Action: func(c *cli.Context) error {
 			v := version.Version(c.Args().First())

--- a/internal/cmd/use.go
+++ b/internal/cmd/use.go
@@ -79,7 +79,8 @@ func validateVersionArg(c *cli.Context) error {
 	}
 	v := c.Args().First()
 	if matched := globals.EnvoyMinorVersionPattern.MatchString(v); !matched {
-		return NewValidationError("invalid [version] argument: %q should look like %q", v, version.LastKnownEnvoy)
+		return NewValidationError("invalid [version] argument: %q should look like %q or %q", v, version.LastKnownEnvoy,
+			version.LastKnownMinorVersionEnvoy)
 	}
 	return nil
 }

--- a/internal/cmd/use_test.go
+++ b/internal/cmd/use_test.go
@@ -37,12 +37,12 @@ func TestFuncEUse_VersionValidates(t *testing.T) {
 	tests := []struct{ name, version, expectedErr string }{
 		{
 			name:        "version empty",
-			expectedErr: fmt.Sprintf(`invalid [version] argument: "" should look like "%s"`, version.LastKnownEnvoy),
+			expectedErr: fmt.Sprintf(`invalid [version] argument: "" should look like %q or %q`, version.LastKnownEnvoy, version.LastKnownMinorVersionEnvoy),
 		},
 		{
 			name:        "version invalid",
 			version:     "a.b.c",
-			expectedErr: fmt.Sprintf(`invalid [version] argument: "a.b.c" should look like "%s"`, version.LastKnownEnvoy),
+			expectedErr: fmt.Sprintf(`invalid [version] argument: "a.b.c" should look like %q or %q`, version.LastKnownEnvoy, version.LastKnownMinorVersionEnvoy),
 		},
 	}
 
@@ -162,12 +162,12 @@ func TestFuncEUse_InstallMinorVersionCheckLatestPatchFailed(t *testing.T) {
 	defer cleanup()
 
 	// The initial version to be installed.
-	initial := avaliableVersions{
-		latestPatch: "3",
-		versions:    []version.Version{"1.12.3"},
-	}
 	minorVersion := "1.12"
 	latestPatch := "3"
+	initial := avaliableVersions{
+		latestPatch: latestPatch,
+		versions:    []version.Version{version.Version(minorVersion + "." + latestPatch)},
+	}
 
 	var err error
 	o.FuncEVersions, err = newFuncEVersionsTester(o, initial)

--- a/internal/cmd/use_test.go
+++ b/internal/cmd/use_test.go
@@ -15,6 +15,8 @@
 package cmd_test
 
 import (
+	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -22,6 +24,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/tetratelabs/func-e/internal/envoy"
+	"github.com/tetratelabs/func-e/internal/globals"
 	"github.com/tetratelabs/func-e/internal/moreos"
 	"github.com/tetratelabs/func-e/internal/version"
 )
@@ -72,4 +76,173 @@ func TestFuncEUse_InstallsAndWritesHomeVersion(t *testing.T) {
 	f, err := os.ReadFile(filepath.Join(o.HomeDir, "version"))
 	require.NoError(t, err)
 	require.Equal(t, o.EnvoyVersion, version.Version(f))
+}
+
+func TestFuncEUse_InstallMinorVersion(t *testing.T) {
+	o, cleanup := setupTest(t)
+	defer cleanup()
+
+	type testCase struct {
+		name           string
+		firstVersions  avaliableVersions
+		secondVersions avaliableVersions
+		minorVersion   string
+	}
+
+	tests := []testCase{
+		{
+			name: "upgradable",
+			firstVersions: avaliableVersions{
+				latestPatch: "3",
+				versions:    []version.Version{"1.18.3"},
+			},
+			secondVersions: avaliableVersions{
+				latestPatch: "4",
+				versions:    []version.Version{"1.18.3", "1.18.4"},
+			},
+			minorVersion: "1.18",
+		},
+		{
+			name: "not-upgraded",
+			firstVersions: avaliableVersions{
+				latestPatch: "3",
+				versions:    []version.Version{"1.12.3"},
+			},
+			secondVersions: avaliableVersions{
+				latestPatch: "3",
+				versions:    []version.Version{"1.12.3"},
+			},
+			minorVersion: "1.12",
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			var err error
+			o.FuncEVersions, err = newFuncEVersionsTester(o, tc.firstVersions)
+			require.NoError(t, err)
+
+			c, _, _ := newApp(o)
+			require.NoError(t, c.Run([]string{"func-e", "use", tc.minorVersion}))
+			f, err := os.ReadFile(filepath.Join(o.HomeDir, "version"))
+			require.NoError(t, err)
+			require.Equal(t, version.Version(tc.minorVersion), version.Version(f))
+
+			// Set o.EnvoyVersion to empty string so the logic for ensuring installed Envoy version works.
+			o.EnvoyVersion = ""
+			c, stdout, stderr := newApp(o)
+			require.NoError(t, c.Run([]string{"func-e", "which"}))
+			envoyPath := filepath.Join(o.HomeDir, "versions", tc.minorVersion+"."+tc.firstVersions.latestPatch, "bin", "envoy"+moreos.Exe)
+			require.Equal(t, moreos.Sprintf("%s\n", envoyPath), stdout.String())
+			require.Empty(t, stderr)
+
+			// Update the map returned by Get.
+			o.FuncEVersions, err = newFuncEVersionsTester(o, tc.secondVersions)
+			require.NoError(t, err)
+			c, _, _ = newApp(o)
+			require.NoError(t, c.Run([]string{"func-e", "use", tc.minorVersion}))
+			f, err = os.ReadFile(filepath.Join(o.HomeDir, "version"))
+			require.NoError(t, err)
+			require.Equal(t, version.Version(tc.minorVersion), version.Version(f))
+
+			// Set o.EnvoyVersion to empty string so the logic for ensuring installed Envoy version works.
+			o.EnvoyVersion = ""
+			c, stdout, stderr = newApp(o)
+			require.NoError(t, c.Run([]string{"func-e", "which"}))
+			envoyPath = filepath.Join(o.HomeDir, "versions", tc.minorVersion+"."+tc.secondVersions.latestPatch, "bin", "envoy"+moreos.Exe)
+			require.Equal(t, moreos.Sprintf("%s\n", envoyPath), stdout.String())
+			require.Empty(t, stderr)
+		})
+	}
+}
+
+func TestFuncEUse_InstallMinorVersionCheckLatestPatchFailed(t *testing.T) {
+	o, cleanup := setupTest(t)
+	defer cleanup()
+
+	// The initial version to be installed.
+	initial := avaliableVersions{
+		latestPatch: "3",
+		versions:    []version.Version{"1.12.3"},
+	}
+	minorVersion := "1.12"
+	latestPatch := "3"
+
+	var err error
+	o.FuncEVersions, err = newFuncEVersionsTester(o, initial)
+	require.NoError(t, err)
+
+	c, _, _ := newApp(o)
+	require.NoError(t, c.Run([]string{"func-e", "use", minorVersion}))
+	f, err := os.ReadFile(filepath.Join(o.HomeDir, "version"))
+	require.NoError(t, err)
+	require.Equal(t, version.Version(minorVersion), version.Version(f))
+
+	o.EnvoyVersion = ""
+	c, stdout, stderr := newApp(o)
+	require.NoError(t, c.Run([]string{"func-e", "which"}))
+	envoyPath := filepath.Join(o.HomeDir, "versions", minorVersion+"."+latestPatch, "bin", "envoy"+moreos.Exe)
+	require.Equal(t, moreos.Sprintf("%s\n", envoyPath), stdout.String())
+	require.Empty(t, stderr)
+
+	// Simulate failure in fetching Envoy release versions by initializing o.FuncEVersions with empty
+	// available versions.
+	o.FuncEVersions = &funcEVersionsTester{}
+	c, _, _ = newApp(o)
+	require.NoError(t, c.Run([]string{"func-e", "use", minorVersion}))
+	f, err = os.ReadFile(filepath.Join(o.HomeDir, "version"))
+	require.NoError(t, err)
+	require.Equal(t, version.Version(minorVersion), version.Version(f))
+
+	o.EnvoyVersion = ""
+	c, stdout, stderr = newApp(o)
+	require.NoError(t, c.Run([]string{"func-e", "which"}))
+	// The path points to the latest installed version.
+	envoyPath = filepath.Join(o.HomeDir, "versions", minorVersion+"."+latestPatch, "bin", "envoy"+moreos.Exe)
+	t.Log(stdout.String())
+	require.Equal(t, moreos.Sprintf("%s\n", envoyPath), stdout.String())
+	require.Empty(t, stderr)
+}
+
+type avaliableVersions struct {
+	latestPatch string
+	versions    []version.Version
+}
+
+type funcEVersionsTester struct {
+	ev version.ReleaseVersions
+	av avaliableVersions
+}
+
+func newFuncEVersionsTester(o *globals.GlobalOpts, av avaliableVersions) (version.FuncEVersions, error) {
+	feV := envoy.NewFuncEVersions(o.EnvoyVersionsURL, o.Platform, o.Version)
+	ev, err := feV.Get(context.Background())
+	if err != nil {
+		return nil, err
+	}
+	// Copy versions releases from the setupTest and append more versions for testing.
+	copied := ev
+	var m version.Release
+	for _, entry := range ev.Versions {
+		m = entry
+		break
+	}
+	for _, v := range av.versions {
+		copied.Versions[v] = m
+	}
+	return &funcEVersionsTester{ev: copied, av: av}, nil
+}
+
+func (f *funcEVersionsTester) Get(ctx context.Context) (version.ReleaseVersions, error) {
+	return f.ev, nil
+}
+
+func (f *funcEVersionsTester) FindLatestPatch(ctx context.Context, minorVersion version.Version) (version.Version, error) {
+	// When the input latest patch is empty, send error. This is useful for simulating FindLatestPatch
+	// to return error.
+	if f.av.latestPatch == "" {
+		return "", errors.New("failed to find latest patch")
+	}
+	return version.Version(string(minorVersion) + "." + f.av.latestPatch), nil
 }

--- a/internal/envoy/version.go
+++ b/internal/envoy/version.go
@@ -66,7 +66,7 @@ func verifyVersion(v version.Version, source string, err error) error {
 	if err != nil {
 		return moreos.Errorf(`couldn't read version from %s: %w`, source, err)
 	}
-	if matched := globals.EnvoyVersionPattern.MatchString(string(v)); !matched {
+	if matched := globals.EnvoyMinorVersionPattern.MatchString(string(v)); !matched {
 		return moreos.Errorf(`invalid version in %q: %q should look like %q`, source, v, version.LastKnownEnvoy)
 	}
 	return nil

--- a/internal/globals/globals.go
+++ b/internal/globals/globals.go
@@ -53,7 +53,9 @@ type GlobalOpts struct {
 	// EnvoyVersionsURL is the path to the envoy-versions.json. Defaults to DefaultEnvoyVersionsURL
 	EnvoyVersionsURL string
 	// EnvoyVersion is the default version of Envoy to run. Defaults to the contents of "$HomeDir/versions/version".
-	// When that file is missing, it is generated from ".latestVersion" from the EnvoyVersionsURL.
+	// When that file is missing, it is generated from ".latestVersion" from the EnvoyVersionsURL. Its
+	// value can be in full version major.minor.patch format, e.g. 1.18.1 or without patch component,
+	// major.minor, e.g. 1.18.
 	EnvoyVersion version.Version
 	// HomeDir is an absolute path which most importantly contains "versions" installed from EnvoyVersionsURL. Defaults to DefaultHomeDir
 	HomeDir string

--- a/internal/globals/globals.go
+++ b/internal/globals/globals.go
@@ -91,4 +91,7 @@ var (
 	EnvoyVersionPattern = regexp.MustCompile(`^[1-9][0-9]*\.[0-9]+\.[0-9]+(_debug)?$`)
 	// EnvoyMinorVersionPattern is EnvoyVersionPattern but with optional patch and _debug components.
 	EnvoyMinorVersionPattern = regexp.MustCompile(`^[1-9][0-9]*\.[0-9]+(\.[0-9]+)?(_debug)?$`)
+	// EnvoyStrictMinorVersionPattern is used to validated minor versions. A Minor version is just
+	// like envoy.Version format, except missing the patch. For example: 1.18 or 1.20_debug.
+	EnvoyStrictMinorVersionPattern = regexp.MustCompile(`^[1-9][0-9]*\.[0-9]+(_debug)?$`)
 )

--- a/internal/globals/globals_test.go
+++ b/internal/globals/globals_test.go
@@ -1,0 +1,98 @@
+// Copyright 2021 Tetrate
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package globals_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/tetratelabs/func-e/internal/globals"
+)
+
+func TestEnvoyVersionPattern_Valid(t *testing.T) {
+	versions := []string{
+		"1.1.1", "1.18.1", "1.18.1_debug",
+	}
+
+	for _, v := range versions {
+		require.True(t, globals.EnvoyVersionPattern.MatchString(v))
+	}
+}
+
+func TestEnvoyVersionPattern_Invalid(t *testing.T) {
+	versions := []string{
+		"a.b.c", "1", "1.1", "1.1_debug",
+	}
+
+	for _, v := range versions {
+		require.False(t, globals.EnvoyVersionPattern.MatchString(v))
+	}
+}
+
+func TestEnvoyStrictMinorVersionPattern_Valid(t *testing.T) {
+	versions := []string{
+		"1.1", "1.18", "1.18_debug",
+	}
+
+	for _, v := range versions {
+		require.True(t, globals.EnvoyStrictMinorVersionPattern.MatchString(v))
+	}
+}
+
+func TestEnvoyStrictMinorVersionPattern_Invalid(t *testing.T) {
+	versions := []string{
+		"a.b",
+		"1.18-debug",
+		"1", "1.", ".1",
+		"1.1.1", "1.1.1_debug",
+	}
+
+	for _, v := range versions {
+		require.False(t, globals.EnvoyStrictMinorVersionPattern.MatchString(v))
+	}
+}
+
+func TestEnvoyMinorVersionPattern_CapturePatchComponent(t *testing.T) {
+	type testCase struct {
+		version                string
+		capturedPatchComponent string
+	}
+
+	tests := []testCase{
+		{
+			version:                "1.1",
+			capturedPatchComponent: "",
+		},
+		{
+			version:                "1.1.1",
+			capturedPatchComponent: ".1",
+		},
+		{
+			version:                "1.1.1_debug",
+			capturedPatchComponent: ".1",
+		},
+	}
+
+	for _, tc := range tests {
+		var matched [][]string
+		if matched = globals.EnvoyMinorVersionPattern.FindAllStringSubmatch(tc.version, -1); matched == nil {
+			for _, sub := range matched {
+				require.Equal(t, sub[0], tc.capturedPatchComponent)
+			}
+			continue
+		}
+	}
+}

--- a/internal/globals/globals_test.go
+++ b/internal/globals/globals_test.go
@@ -88,9 +88,9 @@ func TestEnvoyMinorVersionPattern_CapturePatchComponent(t *testing.T) {
 
 	for _, tc := range tests {
 		var matched [][]string
-		if matched = globals.EnvoyMinorVersionPattern.FindAllStringSubmatch(tc.version, -1); matched == nil {
+		if matched = globals.EnvoyMinorVersionPattern.FindAllStringSubmatch(tc.version, -1); matched != nil {
 			for _, sub := range matched {
-				require.Equal(t, sub[0], tc.capturedPatchComponent)
+				require.Equal(t, sub[1], tc.capturedPatchComponent)
 			}
 			continue
 		}

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -15,7 +15,10 @@
 // Package version declares types for each string to keep strict coupling to the JSON schema
 package version
 
-import _ "embed" // We embed the Envoy version so that we can cache it in CI
+import (
+	_ "embed" // We embed the Envoy version so that we can cache it in CI
+	"strings"
+)
 
 //go:embed last_known_envoy.txt
 var lastKnownEnvoy string
@@ -28,6 +31,9 @@ var lastKnownEnvoy string
 // built, a more recent "latestVersion" can be used, even if the help statements only know about the one from compile
 // time.
 var LastKnownEnvoy = Version(lastKnownEnvoy)
+
+// LastKnownMinorVersionEnvoy is LastKnownEnvoy wihout the patch component.
+var LastKnownMinorVersionEnvoy = Version(lastKnownEnvoy[:strings.LastIndex(lastKnownEnvoy, ".")])
 
 // ReleaseVersions primarily maps Version to TarballURL and tracks the LatestVersion
 type ReleaseVersions struct {


### PR DESCRIPTION
This changeset introduces a way to switch the Envoy version using compatible
Envoy version (for example 1.18) and automatically infer the available
patched version to be downloaded. For instance, if the currently
downloaded version is 1.18.3, and the remote one has 1.18.4, calling
"use" downloads and sets the current version to 1.18.4.

Fixes #360 

Signed-off-by: Dhi Aurrahman <dio@tetrate.io>