### PR TITLE
build: Add *.go as prerequisite for building current binary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,8 +59,16 @@ non_windows_platforms := darwin_amd64 darwin_arm64 linux_amd64 linux_arm64
 # TODO: arm64 on Windows https://github.com/envoyproxy/envoy/issues/17572
 windows_platforms := windows_amd64
 
-$(build_dir)/func-e_%/func-e: main.go
-	$(call go-build, $@, $^)
+# TODO: To have expression that understand globbing for any depth.
+gocodes := [!_test].go
+subdirs := $(wildcard */)
+sources := $(wildcard \
+	$(addsuffix *$(gocodes),$(subdirs)) \
+	$(addsuffix */*$(gocodes),$(subdirs)) \
+	$(addsuffix */*/*$(gocodes),$(subdirs)))
+
+$(build_dir)/func-e_%/func-e: main.go $(sources)
+	$(call go-build, $@, main.go)
 
 $(dist_dir)/func-e_$(VERSION)_%.tar.gz: $(build_dir)/func-e_%/func-e
 	@printf "$(ansi_format_dark)" tar.gz "tarring $@"
@@ -68,8 +76,8 @@ $(dist_dir)/func-e_$(VERSION)_%.tar.gz: $(build_dir)/func-e_%/func-e
 	@tar --strip-components 2 -cpzf $@ $<
 	@printf "$(ansi_format_bright)" tar.gz "ok"
 
-$(build_dir)/func-e_%/func-e.exe: main.go
-	$(call go-build, $@, $^)
+$(build_dir)/func-e_%/func-e.exe: main.go $(sources)
+	$(call go-build, $@, main.go)
 
 $(dist_dir)/func-e_$(VERSION)_%.zip: $(build_dir)/func-e_%/func-e.exe.signed
 	@printf "$(ansi_format_dark)" zip "zipping $@"

--- a/Makefile
+++ b/Makefile
@@ -59,6 +59,7 @@ non_windows_platforms := darwin_amd64 darwin_arm64 linux_amd64 linux_arm64
 # TODO: arm64 on Windows https://github.com/envoyproxy/envoy/issues/17572
 windows_platforms := windows_amd64
 
+# Excludes all *_test.go files.
 gocodes := [!_test].go
 sources := $(wildcard internal/*/*$(gocodes) internal/*/*/*$(gocodes))
 

--- a/Makefile
+++ b/Makefile
@@ -59,16 +59,11 @@ non_windows_platforms := darwin_amd64 darwin_arm64 linux_amd64 linux_arm64
 # TODO: arm64 on Windows https://github.com/envoyproxy/envoy/issues/17572
 windows_platforms := windows_amd64
 
-# TODO: To have expression that understand globbing for any depth.
 gocodes := [!_test].go
-subdirs := $(wildcard */)
-sources := $(wildcard \
-	$(addsuffix *$(gocodes),$(subdirs)) \
-	$(addsuffix */*$(gocodes),$(subdirs)) \
-	$(addsuffix */*/*$(gocodes),$(subdirs)))
+sources := $(wildcard internal/*/*$(gocodes) internal/*/*/*$(gocodes))
 
 $(build_dir)/func-e_%/func-e: main.go $(sources)
-	$(call go-build, $@, main.go)
+	$(call go-build, $@, $<)
 
 $(dist_dir)/func-e_$(VERSION)_%.tar.gz: $(build_dir)/func-e_%/func-e
 	@printf "$(ansi_format_dark)" tar.gz "tarring $@"
@@ -77,7 +72,7 @@ $(dist_dir)/func-e_$(VERSION)_%.tar.gz: $(build_dir)/func-e_%/func-e
 	@printf "$(ansi_format_bright)" tar.gz "ok"
 
 $(build_dir)/func-e_%/func-e.exe: main.go $(sources)
-	$(call go-build, $@, main.go)
+	$(call go-build, $@, $<)
 
 $(dist_dir)/func-e_$(VERSION)_%.zip: $(build_dir)/func-e_%/func-e.exe.signed
 	@printf "$(ansi_format_dark)" zip "zipping $@"


### PR DESCRIPTION
This adds sources (`*.go` except `*_test.go`) as prerequisites for building
the `current_binary` target. This forces rebuilding the `current_binary` 
target when any of `*.go` is changed.

Signed-off-by: Dhi Aurrahman <dio@tetrate.io>