### PR TITLE
Add FuncEVersions interface and its default implementation

### DIFF
--- a/internal/cmd/app.go
+++ b/internal/cmd/app.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/urfave/cli/v2"
 
+	"github.com/tetratelabs/func-e/internal/envoy"
 	"github.com/tetratelabs/func-e/internal/globals"
 	"github.com/tetratelabs/func-e/internal/moreos"
 	"github.com/tetratelabs/func-e/internal/version"
@@ -85,7 +86,11 @@ func NewApp(o *globals.GlobalOpts) *cli.App {
 		if err := setHomeDir(o, homeDir); err != nil {
 			return err
 		}
-		return setEnvoyVersionsURL(o, envoyVersionsURL)
+		if err := setEnvoyVersionsURL(o, envoyVersionsURL); err != nil {
+			return err
+		}
+		o.FuncEVersions = envoy.NewFuncEVersions(o.EnvoyVersionsURL, o.Platform, o.Version)
+		return nil
 	}
 
 	app.HideHelp = true

--- a/internal/cmd/app_test.go
+++ b/internal/cmd/app_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/urfave/cli/v2"
 
 	rootcmd "github.com/tetratelabs/func-e/internal/cmd"
+	"github.com/tetratelabs/func-e/internal/envoy"
 	"github.com/tetratelabs/func-e/internal/globals"
 	"github.com/tetratelabs/func-e/internal/test"
 	"github.com/tetratelabs/func-e/internal/version"
@@ -252,6 +253,8 @@ func setupTest(t *testing.T) (*globals.GlobalOpts, func()) {
 	versionsServer := test.RequireEnvoyVersionsTestServer(t, version.LastKnownEnvoy)
 	result.EnvoyVersionsURL = versionsServer.URL + "/envoy-versions.json"
 	tearDown = append(tearDown, versionsServer.Close)
+
+	result.FuncEVersions = envoy.NewFuncEVersions(result.EnvoyVersionsURL, result.Platform, result.Version)
 
 	return &result, func() {
 		for i := len(tearDown) - 1; i >= 0; i-- {

--- a/internal/cmd/run.go
+++ b/internal/cmd/run.go
@@ -127,7 +127,7 @@ func setHomeEnvoyVersion(ctx context.Context, o *globals.GlobalOpts) error {
 
 	// First time install: look up the latest version, which may be newer than version.LastKnownEnvoy!
 	o.Logf("looking up the latest Envoy version\n") //nolint
-	m, err := envoy.FuncEVersions(ctx, o.EnvoyVersionsURL, o.Platform, o.Version)
+	m, err := o.FuncEVersions.Get(ctx)
 	if err != nil {
 		return NewValidationError(`couldn't read latest version from %s: %s`, o.EnvoyVersionsURL, err)
 	}

--- a/internal/cmd/versions.go
+++ b/internal/cmd/versions.go
@@ -51,7 +51,7 @@ func NewVersionsCmd(o *globals.GlobalOpts) *cli.Command {
 			currentVersion, currentVersionSource, _ := envoy.CurrentVersion(o.HomeDir)
 
 			if c.Bool("all") {
-				if ev, err := envoy.FuncEVersions(c.Context, o.EnvoyVersionsURL, o.Platform, o.Version); err != nil {
+				if ev, err := o.FuncEVersions.Get(c.Context); err != nil {
 					return err
 				} else if err := addAvailableVersions(&rows, ev.Versions, o.Platform); err != nil {
 					return err

--- a/internal/envoy/install.go
+++ b/internal/envoy/install.go
@@ -39,7 +39,7 @@ func InstallIfNeeded(ctx context.Context, o *globals.GlobalOpts, v version.Versi
 	switch {
 	case os.IsNotExist(err):
 		var ev version.ReleaseVersions // Get version metadata for what we will install
-		ev, err = FuncEVersions(ctx, o.EnvoyVersionsURL, o.Platform, v)
+		ev, err = o.FuncEVersions.Get(ctx)
 		if err != nil {
 			return "", err
 		}

--- a/internal/envoy/install_test.go
+++ b/internal/envoy/install_test.go
@@ -107,6 +107,7 @@ func TestInstallIfNeeded_ErrorOnIncorrectURL(t *testing.T) {
 	defer cleanup()
 
 	o.EnvoyVersionsURL += "/varsionz.json"
+	o.FuncEVersions = NewFuncEVersions(o.EnvoyVersionsURL, o.Platform, o.Version)
 
 	_, err := InstallIfNeeded(o.ctx, &o.GlobalOpts, version.LastKnownEnvoy)
 	require.EqualError(t, err, "received 404 status code from "+o.EnvoyVersionsURL)
@@ -246,7 +247,7 @@ type installTest struct {
 func setupInstallTest(t *testing.T) (*installTest, func()) {
 	versionsServer := test.RequireEnvoyVersionsTestServer(t, version.LastKnownEnvoy)
 	homeDir := t.TempDir()
-	return &installTest{
+	setup := &installTest{
 		ctx:        context.Background(),
 		tempDir:    t.TempDir(),
 		tarballURL: test.TarballURL(versionsServer.URL, runtime.GOOS, runtime.GOARCH, version.LastKnownEnvoy),
@@ -259,5 +260,7 @@ func setupInstallTest(t *testing.T) (*installTest, func()) {
 				EnvoyPath: filepath.Join(homeDir, "versions", string(version.LastKnownEnvoy), binEnvoy),
 			},
 		},
-	}, versionsServer.Close
+	}
+	setup.FuncEVersions = NewFuncEVersions(setup.EnvoyVersionsURL, setup.Platform, setup.Version)
+	return setup, versionsServer.Close
 }

--- a/internal/envoy/versions.go
+++ b/internal/envoy/versions.go
@@ -20,30 +20,94 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strconv"
+	"strings"
 
+	"github.com/tetratelabs/func-e/internal/globals"
 	"github.com/tetratelabs/func-e/internal/version"
 )
 
-// FuncEVersions returns a version map from a remote URL. eg globals.DefaultEnvoyVersionsURL.
-func FuncEVersions(ctx context.Context, envoyVersionsURL string, p version.Platform, v version.Version) (version.ReleaseVersions, error) {
+// NewFuncEVersions creates a new Envoy versions fetcher.
+func NewFuncEVersions(envoyVersionsURL string, p version.Platform, v version.Version) version.FuncEVersions {
+	feV := &funcEVersions{envoyVersionsURL: envoyVersionsURL, platform: p, version: v}
+	feV.getFunc = feV.Get
+	return feV
+}
+
+type funcEVersions struct {
+	envoyVersionsURL string
+	platform         version.Platform
+	version          version.Version
+
+	// getFunc allows to override the release versions getter implementation.
+	getFunc func(ctx context.Context) (version.ReleaseVersions, error)
+}
+
+var _ version.FuncEVersions = (*funcEVersions)(nil)
+
+// Get implements fetching the Envoy versions from the specified Envoy versions URL.
+func (f *funcEVersions) Get(ctx context.Context) (version.ReleaseVersions, error) {
 	result := version.ReleaseVersions{}
 	// #nosec => This is by design, users can call out to wherever they like!
-	resp, err := httpGet(ctx, envoyVersionsURL, p, v)
+	resp, err := httpGet(ctx, f.envoyVersionsURL, f.platform, f.version)
 	if err != nil {
 		return result, err
 	}
 	defer resp.Body.Close() //nolint
 
 	if resp.StatusCode != http.StatusOK {
-		return result, fmt.Errorf("received %v status code from %v", resp.StatusCode, envoyVersionsURL)
+		return result, fmt.Errorf("received %v status code from %v", resp.StatusCode, f.envoyVersionsURL)
 	}
 	body, err := io.ReadAll(resp.Body) // fully read the response
 	if err != nil {
-		return result, fmt.Errorf("error reading %s: %w", envoyVersionsURL, err)
+		return result, fmt.Errorf("error reading %s: %w", f.envoyVersionsURL, err)
 	}
 
 	if err := json.Unmarshal(body, &result); err != nil {
 		return result, fmt.Errorf("error unmarshalling Envoy versions: %w", err)
 	}
 	return result, nil
+}
+
+// FindLatestPatch implements finding the latest patch version for the given minor version or raises
+// an error. The Envoy release versions fetching logic can be overridden by setting the getFunc with
+// different implementation.
+func (f *funcEVersions) FindLatestPatch(ctx context.Context, minorVersion version.Version) (version.Version, error) {
+	var latestPatch int
+	var latestVersion version.Version
+
+	releases, err := f.getFunc(ctx)
+	if err != nil {
+		return "", err
+	}
+	for v := range releases.Versions {
+		// The "." suffix is required to avoild false-matching, e.g. 1.1 to 1.18.
+		if !strings.HasPrefix(string(v), string(minorVersion)+".") {
+			continue
+		}
+
+		var matched [][]string
+		if matched = globals.EnvoyMinorVersionPattern.FindAllStringSubmatch(string(v), -1); matched == nil {
+			continue
+		}
+		for _, sub := range matched {
+			// A matched patch component should look like ".4".
+			if !strings.HasPrefix(sub[1], ".") {
+				continue
+			}
+			var p int
+			if p, err = strconv.Atoi(sub[1][1:]); err != nil {
+				continue
+			}
+			if p >= latestPatch {
+				latestPatch = p
+				latestVersion = v
+			}
+		}
+	}
+
+	if latestVersion == "" {
+		return "", fmt.Errorf("couldn't find latest version for %q", minorVersion)
+	}
+	return latestVersion, nil
 }

--- a/internal/envoy/versions_test.go
+++ b/internal/envoy/versions_test.go
@@ -16,7 +16,6 @@ package envoy
 
 import (
 	"context"
-	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -66,7 +65,7 @@ func TestFuncEVersions_FindLatestPatch(t *testing.T) {
 			tester := newFuncEVersionsTester(tc.versions)
 			have, err := tester.feV.FindLatestPatch(ctx, tc.input)
 			if tc.want == "" {
-				require.Error(t, fmt.Errorf("couldn't find latest version for %s", tc.input))
+				require.Errorf(t, err, "couldn't find latest version for %s", tc.input)
 			} else {
 				require.NoError(t, err)
 				require.Equal(t, have, tc.want)

--- a/internal/envoy/versions_test.go
+++ b/internal/envoy/versions_test.go
@@ -1,0 +1,91 @@
+// Copyright 2021 Tetrate
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package envoy
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/tetratelabs/func-e/internal/version"
+)
+
+func TestFuncEVersions_FindLatestVersions(t *testing.T) {
+	type testCase struct {
+		name     string
+		input    version.Version
+		versions map[version.Version]version.Release
+		want     version.Version
+	}
+
+	tests := []testCase{
+		{
+			name:  "zero",
+			input: "1.20",
+			versions: map[version.Version]version.Release{
+				"1.20.0": {},
+			},
+			want: "1.20.0",
+		},
+		{
+			name:  "upgradable",
+			input: "1.18",
+			versions: map[version.Version]version.Release{
+				"1.18.3": {},
+				"1.18.4": {},
+			},
+			want: "1.18.4",
+		},
+		{
+			name:  "notfound",
+			input: "1.1",
+			versions: map[version.Version]version.Release{
+				"1.20.0": {},
+			},
+			want: "",
+		},
+	}
+
+	ctx := context.Background()
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			tester := newFuncEVersionsTester(tc.versions)
+			have, err := tester.feV.FindLatestPatch(ctx, tc.input)
+			if tc.want == "" {
+				require.Error(t, fmt.Errorf("couldn't find latest version for %s", tc.input))
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, have, tc.want)
+			}
+		})
+	}
+}
+
+type funcEVersionsTester struct {
+	feV funcEVersions
+}
+
+func newFuncEVersionsTester(versions map[version.Version]version.Release) funcEVersionsTester {
+	return funcEVersionsTester{
+		feV: funcEVersions{
+			// Override Envoy versions getter for testing purpose only.
+			getFunc: func(context.Context) (version.ReleaseVersions, error) {
+				return version.ReleaseVersions{Versions: versions}, nil
+			},
+		},
+	}
+}

--- a/internal/envoy/versions_test.go
+++ b/internal/envoy/versions_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/tetratelabs/func-e/internal/version"
 )
 
-func TestFuncEVersions_FindLatestVersions(t *testing.T) {
+func TestFuncEVersions_FindLatestPatch(t *testing.T) {
 	type testCase struct {
 		name     string
 		input    version.Version

--- a/internal/globals/globals.go
+++ b/internal/globals/globals.go
@@ -63,6 +63,8 @@ type GlobalOpts struct {
 	Out io.Writer
 	// The platform to target for the Envoy install.
 	Platform version.Platform
+	//
+	FuncEVersions version.FuncEVersions
 }
 
 // Logf is used for shared functions that log conditionally on GlobalOpts.Quiet
@@ -87,4 +89,6 @@ var (
 	DefaultHomeDir = moreos.ReplacePathSeparator("${HOME}/.func-e")
 	// EnvoyVersionPattern is used to validate versions and is the same pattern as release-versions-schema.json.
 	EnvoyVersionPattern = regexp.MustCompile(`^[1-9][0-9]*\.[0-9]+\.[0-9]+(_debug)?$`)
+	// EnvoyMinorVersionPattern is EnvoyVersionPattern but with optional patch and _debug components.
+	EnvoyMinorVersionPattern = regexp.MustCompile(`^[1-9][0-9]*\.[0-9]+(\.[0-9]+)?(_debug)?$`)
 )

--- a/internal/globals/globals.go
+++ b/internal/globals/globals.go
@@ -63,7 +63,7 @@ type GlobalOpts struct {
 	Out io.Writer
 	// The platform to target for the Envoy install.
 	Platform version.Platform
-	//
+	// FuncEVersions is the interface for fetching Envoy release versions map from the EnvoyVersionsURL.
 	FuncEVersions version.FuncEVersions
 }
 

--- a/internal/version/versions.go
+++ b/internal/version/versions.go
@@ -1,0 +1,27 @@
+// Copyright 2021 Tetrate
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package version
+
+import "context"
+
+// FuncEVersions fetches a version map from a remote URL and gets the latest patched version given
+// a version input. This input can be major.minor.patch (e.g. 1.1.1) or major.minor (1.1).
+type FuncEVersions interface {
+	// Get returns a version map from a remote URL. e.g. from globals.DefaultEnvoyVersionsURL.
+	Get(context.Context) (ReleaseVersions, error)
+
+	// FindLatestPatch finds the latest patch version for the given minor version or raises an error.
+	FindLatestPatch(context.Context, Version) (Version, error)
+}


### PR DESCRIPTION
This patch introduces FuncEVersions as an interface for easier testing,
especially when simulating failure on getting the remote Envoy release
versions map.

This also provides the default implementation of FuncEVersions, which
converts the existing functionality via Get() method and also a way to
find a latest patch given Envoy release versions map and a minor
version.

Signed-off-by: Dhi Aurrahman <dio@rockybars.com>