### PR TITLE
Parse date string using system local as its timezone

### DIFF
--- a/.github/workflows/commit.yaml
+++ b/.github/workflows/commit.yaml
@@ -105,10 +105,6 @@ jobs:
           # See: http://www.unicode.org/cldr/charts/latest/supplemental/zone_tzid.html.
           timezoneWindows: "US Mountain Standard Time"
 
-      - name: "Check to be sure"
-        if: runner.os == 'Linux'
-        run: timedatectl
-
       - name: "Run unit tests in a different timezone"
         run: make test
 

--- a/.github/workflows/commit.yaml
+++ b/.github/workflows/commit.yaml
@@ -97,16 +97,11 @@ jobs:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         run: bash <(curl -s https://codecov.io/bash)
 
-      - name: "Change timezone" # https://github.com/tetratelabs/func-e/issues/303.
-        uses: szenius/set-timezone@v1.0
-        with:
-          timezoneLinux: "America/Phoenix"
-          timezoneMacos: "America/Phoenix"
-          # See: http://www.unicode.org/cldr/charts/latest/supplemental/zone_tzid.html.
-          timezoneWindows: "US Mountain Standard Time"
-
-      - name: "Run unit tests in a different timezone"
-        run: make test
+      - name: "Run unit tests in a different timezone" # https://github.com/tetratelabs/func-e/issues/303.
+        if: runner.os == 'Linux'
+        run: |
+          timedatectl set-timezone America/Phoenix
+          make test
 
   # Github Action Runners don't support all operating systems we may need to test. Below ensures
   # we run on the intended minimum platforms. Note: we also use Travis for arm64+ubuntu.

--- a/.github/workflows/commit.yaml
+++ b/.github/workflows/commit.yaml
@@ -100,7 +100,7 @@ jobs:
       - name: "Run unit tests in a different timezone" # https://github.com/tetratelabs/func-e/issues/303.
         if: runner.os == 'Linux'
         run: |
-          timedatectl set-timezone America/Phoenix
+          sudo timedatectl set-timezone America/Phoenix
           make test
 
   # Github Action Runners don't support all operating systems we may need to test. Below ensures

--- a/.github/workflows/commit.yaml
+++ b/.github/workflows/commit.yaml
@@ -97,6 +97,17 @@ jobs:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         run: bash <(curl -s https://codecov.io/bash)
 
+      - name: "Change timezone" # https://github.com/tetratelabs/func-e/issues/303.
+        uses: szenius/set-timezone@v1.0
+        with:
+          timezoneLinux: "America/Phoenix"
+          timezoneMacos: "America/Phoenix"
+          # See: http://www.unicode.org/cldr/charts/latest/supplemental/zone_tzid.html.
+          timezoneWindows: "US Mountain Standard Time"
+
+      - name: "Run unit tests in a different timezone"
+        run: make test
+
   # Github Action Runners don't support all operating systems we may need to test. Below ensures
   # we run on the intended minimum platforms. Note: we also use Travis for arm64+ubuntu.
   #

--- a/.github/workflows/commit.yaml
+++ b/.github/workflows/commit.yaml
@@ -105,6 +105,10 @@ jobs:
           # See: http://www.unicode.org/cldr/charts/latest/supplemental/zone_tzid.html.
           timezoneWindows: "US Mountain Standard Time"
 
+      - name: "Check to be sure"
+        if: runner.os == 'Linux'
+        run: timedatectl
+
       - name: "Run unit tests in a different timezone"
         run: make test
 

--- a/internal/test/morerequire/morerequire.go
+++ b/internal/test/morerequire/morerequire.go
@@ -26,7 +26,8 @@ import (
 
 // RequireSetMtime sets the mtime of the dir given a string formatted date. Ex "2006-01-02"
 func RequireSetMtime(t *testing.T, dir, date string) {
-	td, err := time.Parse("2006-01-02", date)
+	// Make sure we do parsing using time.Local to match the time.ModTime's location used for sorting.
+	td, err := time.ParseInLocation("2006-01-02", date, time.Local)
 	require.NoError(t, err)
 	require.NoError(t, os.Chtimes(dir, td, td))
 }


### PR DESCRIPTION
This fixes the timezone bug when doing `Chtimes`. By default `time.Parse`
uses `UTC` while we use `time.Modtime` which uses `time.Local` as its
location.

Fixes https://github.com/tetratelabs/func-e/issues/303.

Signed-off-by: Dhi Aurrahman <dio@rockybars.com>