### PR TITLE
Add tests calling terminating signals to func-e

### DIFF
--- a/internal/moreos/moreos_func-e_test.go
+++ b/internal/moreos/moreos_func-e_test.go
@@ -91,7 +91,7 @@ func Test_CallSignals(t *testing.T) {
 
 			tempDir := t.TempDir()
 
-			// Build a fake envoy and pass the ENV hint so that fake func-e uses it
+			// Build a fake envoy and pass the path via via ENVOY_PATH so that fake func-e uses it.
 			fakeEnvoy := filepath.Join(tempDir, "envoy"+Exe)
 			fakebinary.RequireFakeEnvoy(t, fakeEnvoy)
 			t.Setenv("ENVOY_PATH", fakeEnvoy)
@@ -128,6 +128,10 @@ func Test_CallSignals(t *testing.T) {
 
 			tc.signal(cmd.Process)
 			if tc.waitForExiting {
+				// When we decide to wait for the fake envoy for exiting, we wait for "exiting" message
+				// from envoy (see: internal/test/fakebinary/testdata/fake_envoy.go#82) after receiving
+				// interrupt from func-e (the fake func-e forwards fake envoy's stderr.
+				// See: internal/moreos/testdata/fake_func-e.go#38).
 				requireScannedWaitFor(t, stderrScanner, "exiting")
 			}
 

--- a/internal/moreos/moreos_func-e_test.go
+++ b/internal/moreos/moreos_func-e_test.go
@@ -65,13 +65,13 @@ func Test_CallSignal(t *testing.T) {
 			name:           "SIGTERM",
 			signal:         func(proc *os.Process) error { return proc.Signal(syscall.SIGTERM) },
 			waitForExiting: true,
-			// On windows os.Process.Signal is not implemented; it will return an error instead of sending
+			// On Windows, os.Process.Signal is not implemented; it will return an error instead of sending
 			// a signal.
 			skip: runtime.GOOS == OSWindows,
 		},
 		{
 			name: "kill",
-			// On linux, we propagate SIGKILL to the child process as the configured SysProcAttr.Pdeathsig
+			// On Linux, we propagate SIGKILL to the child process as the configured SysProcAttr.Pdeathsig
 			// in proc_linux.go.
 			signal:         func(proc *os.Process) error { return proc.Kill() },
 			waitForExiting: false, // since the process is killed, it is immediately exit.

--- a/internal/moreos/moreos_func-e_test.go
+++ b/internal/moreos/moreos_func-e_test.go
@@ -82,7 +82,8 @@ func Test_CallSignals(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		tc := tc
+		tc := tc // pin! see https://github.com/kyoh86/scopelint for why.
+
 		t.Run(tc.name, func(t *testing.T) {
 			if tc.skip {
 				t.Skip()

--- a/internal/moreos/moreos_func-e_test.go
+++ b/internal/moreos/moreos_func-e_test.go
@@ -60,6 +60,7 @@ func Test_CallSignal(t *testing.T) {
 			name:           "interrupt",
 			signal:         Interrupt,
 			waitForExiting: true,
+			skip:           runtime.GOOS == OSWindows,
 		},
 		{
 			name:           "SIGTERM",

--- a/internal/moreos/moreos_func-e_test.go
+++ b/internal/moreos/moreos_func-e_test.go
@@ -46,8 +46,8 @@ var (
 	moreosSrcDir embed.FS
 )
 
-// Test_CallSignal tests sending signals to fake func-e.
-func Test_CallSignal(t *testing.T) {
+// Test_CallSignals tests sending signals to fake func-e.
+func Test_CallSignals(t *testing.T) {
 	type testCase struct {
 		name           string
 		signal         func(*os.Process) error
@@ -57,10 +57,9 @@ func Test_CallSignal(t *testing.T) {
 
 	tests := []testCase{
 		{
-			name:           "interrupt",
+			name:           "Interrupt",
 			signal:         Interrupt,
 			waitForExiting: true,
-			skip:           runtime.GOOS == OSWindows,
 		},
 		{
 			name:           "SIGTERM",
@@ -71,7 +70,7 @@ func Test_CallSignal(t *testing.T) {
 			skip: runtime.GOOS == OSWindows,
 		},
 		{
-			name: "kill",
+			name: "Kill",
 			// On Linux, we propagate SIGKILL to the child process as the configured SysProcAttr.Pdeathsig
 			// in proc_linux.go.
 			signal:         func(proc *os.Process) error { return proc.Kill() },
@@ -104,6 +103,7 @@ func Test_CallSignal(t *testing.T) {
 			// With an arg so fakeFuncE runs fakeEnvoy as its child and doesn't exit.
 			arg := string(version.LastKnownEnvoy)
 			cmd := exec.Command(fakeFuncE, "run", arg, "-c")
+			cmd.SysProcAttr = ProcessGroupAttr() // Make sure we have a new process group.
 			cmd.Stdout = stdout
 
 			stderr, err := cmd.StderrPipe()

--- a/internal/moreos/testdata/fake_func-e.go
+++ b/internal/moreos/testdata/fake_func-e.go
@@ -39,7 +39,7 @@ func main() {
 
 	// Like envoy.Run.
 	waitCtx, waitCancel := context.WithCancel(context.Background())
-	sigCtx, _ := signal.NotifyContext(waitCtx, syscall.SIGINT, syscall.SIGTERM)
+	sigCtx, stop := signal.NotifyContext(waitCtx, os.Interrupt, syscall.SIGTERM)
 	defer waitCancel()
 
 	moreos.Fprintf(os.Stdout, "starting: %s\n", strings.Join(cmd.Args, " ")) //nolint
@@ -56,6 +56,10 @@ func main() {
 
 	// Block until we receive SIGINT or are canceled because Envoy has died.
 	<-sigCtx.Done()
+	stop()
+
+	// Simulate handleShutdown like in envoy.Run.
+	_ = moreos.Interrupt(cmd.Process)
 
 	// Block until it exits to ensure file descriptors are closed prior to archival.
 	// Allow up to 5 seconds for a clean stop, killing if it can't for any reason.

--- a/internal/moreos/testdata/fake_func-e.go
+++ b/internal/moreos/testdata/fake_func-e.go
@@ -39,8 +39,10 @@ func main() {
 
 	// Like envoy.Run.
 	waitCtx, waitCancel := context.WithCancel(context.Background())
-	sigCtx, stop := signal.NotifyContext(waitCtx, os.Interrupt, syscall.SIGTERM)
 	defer waitCancel()
+
+	sigCtx, stop := signal.NotifyContext(waitCtx, os.Interrupt, syscall.SIGTERM)
+	defer stop()
 
 	moreos.Fprintf(os.Stdout, "starting: %s\n", strings.Join(cmd.Args, " ")) //nolint
 	if err := cmd.Start(); err != nil {
@@ -56,7 +58,6 @@ func main() {
 
 	// Block until we receive SIGINT or are canceled because Envoy has died.
 	<-sigCtx.Done()
-	stop()
 
 	// Simulate handleShutdown like in envoy.Run.
 	_ = moreos.Interrupt(cmd.Process)


### PR DESCRIPTION
This is a follow-up for https://github.com/tetratelabs/func-e/pull/371#pullrequestreview-752322738 to test a set of possible signals (`SIGINT`, `SIGTERM`, `SIGKILL`) to terminate func-e.

A minor change on checking the stderr: this PR uses a scanner instead of peeking on the buffer since for some reason redirecting `cmd.Stderr` to a buffer doesn't give complete stderr after the process is terminated. Hence here we use a scanner to `io.ReadCloser` returned by `cmd.StderrPipe()` instead.

Signed-off-by: Dhi Aurrahman <dio@rockybars.com>