### PR TITLE
WIP: Tag arm64 images

### DIFF
--- a/.github/workflows/internal-images.yml
+++ b/.github/workflows/internal-images.yml
@@ -66,8 +66,8 @@ jobs:
       # arm64 image by directly specifiying the tag without the need of supplying
       # `--platform linux/arm64`. Using `uses: docker://` only allows to override `args`, but not
       # the `--platform` flag.
-      # Reference: https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#example-using-the-github-packages-container-registry.
-      # Related: https://github.com/actions/virtual-environments/issues/1368.
+      # Reference: https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#example-using-the-github-packages-container-registry
+      # Related: https://github.com/actions/virtual-environments/issues/1368
       - name : Re-tag for arm64 only
         uses: docker/build-push-action@v2
         with:

--- a/.github/workflows/internal-images.yml
+++ b/.github/workflows/internal-images.yml
@@ -43,10 +43,34 @@ jobs:
           #   - needs repo:status, public_repo, write:packages, delete:packages
           password: ${{ secrets.GHCR_TOKEN }}
 
-      - name: Build and push
-        run: |  # This will only push a single architecture, which is fine as we currently only support amd64
+      - name: Setup QEMU
+        uses: docker/setup-qemu-action@v1
+
+      - name: Setup Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Write Dockerfile for ${{ matrix.target-tag }}
+        run: |
           cat > Dockerfile <<'EOF'
           ${{ matrix.dockerfile }}
           EOF
-          docker build -t ghcr.io/tetratelabs/func-e-internal:${{ matrix.target_tag }} .
-          docker push ghcr.io/tetratelabs/func-e-internal:${{ matrix.target_tag }}
+
+      - name : Build and push
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64 # Build and push for amd64 and arm64 architectures.
+          tags:  ghcr.io/${{ github.repository_owner }}/func-e-internal:${{ matrix.target-tag }}
+
+      # We do re-tagging for easier usage when testing using emulation, so we can forcefuly pull
+      # arm64 image by directly specifiying the tag without the need of supplying
+      # `--platform linux/arm64`. Using `uses: docker://` only allows to override `args`, but not
+      # the `--platform` flag.
+      # Reference: https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#example-using-the-github-packages-container-registry.
+      # Related: https://github.com/actions/virtual-environments/issues/1368.
+      - name : Re-tag for arm64 only
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          platforms: linux/arm64 # Build and push for arm64 architecture only.
+          tags:  ghcr.io/${{ github.repository_owner }}/func-e-internal:${{ matrix.target-tag }}-arm64


### PR DESCRIPTION
This builds and pushes arm64 flavor for internal images. This is to support the idea to run the following step when testing installing/uninstalling packages on `linux/arm64` (both for deb and rpm) in packaging workflow (please refer to: https://github.com/tetratelabs/func-e/pull/366).

```yaml
- uses: docker/setup-qemu-action@v1
- uses: docker://ghcr.io/tetratelabs/func-e-internal:ubuntu20.04-arm64
  with:
    args: packaging/nfpm/verify_deb.sh arm64
- uses: docker://ghcr.io/tetratelabs/func-e-internal:centos8-arm64
  with:
    args: packaging/nfpm/verify_rpm.sh aarch64

```

Signed-off-by: Dhi Aurrahman <dio@rockybars.com>