### PR TITLE
Makes fake_func-e more consistent with real func-e

### DIFF
--- a/internal/envoy/run.go
+++ b/internal/envoy/run.go
@@ -30,7 +30,7 @@ import (
 )
 
 // Run execs the binary at the path with the args passed. It is a blocking function that can be shutdown via SIGINT.
-func (r *Runtime) Run(ctx context.Context, args []string) error { //nolint:gocyclo
+func (r *Runtime) Run(ctx context.Context, args []string) error {
 	// We can't use CommandContext even if that seems correct here. The reason is that we need to invoke shutdown hooks,
 	// and they expect the process to still be running. For example, this allows admin API hooks.
 	cmd := exec.Command(r.opts.EnvoyPath, args...) // #nosec -> users can run whatever binary they like!

--- a/internal/envoy/run.go
+++ b/internal/envoy/run.go
@@ -64,8 +64,10 @@ func (r *Runtime) Run(ctx context.Context, args []string) (err error) { //nolint
 	}
 
 	waitCtx, waitCancel := context.WithCancel(ctx)
-	sigCtx, sigCancel := signal.NotifyContext(waitCtx, syscall.SIGINT, syscall.SIGTERM)
 	defer waitCancel()
+
+	sigCtx, sigCancel := signal.NotifyContext(waitCtx, syscall.SIGINT, syscall.SIGTERM)
+	defer sigCancel()
 	r.FakeInterrupt = sigCancel
 
 	// Wait in a goroutine. We may need to kill the process if a signal occurs first.

--- a/internal/envoy/run.go
+++ b/internal/envoy/run.go
@@ -40,7 +40,7 @@ func (r *Runtime) Run(ctx context.Context, args []string) (err error) { //nolint
 
 	// Suppress any error and replace it with the envoy exit status when > 1
 	defer func() {
-		if cmd.ProcessState != nil && cmd.ProcessState.ExitCode() > 0 {
+		if cmd.ProcessState.ExitCode() > 0 {
 			if err != nil {
 				moreos.Fprintf(r.Out, "warning: %s\n", err) //nolint
 			}

--- a/internal/envoy/runtime.go
+++ b/internal/envoy/runtime.go
@@ -25,6 +25,8 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/tetratelabs/func-e/internal/moreos"
+
 	"github.com/tetratelabs/func-e/internal/globals"
 )
 
@@ -73,6 +75,13 @@ func (r *Runtime) String() string {
 // GetRunDir returns the run-specific directory files can be written to.
 func (r *Runtime) GetRunDir() string {
 	return r.opts.RunDir
+}
+
+// maybeWarn writes a warning message to Runtime.Out when the error isn't nil
+func (r *Runtime) maybeWarn(err error) {
+	if err != nil {
+		moreos.Fprintf(r.Out, "warning: %s\n", err) //nolint
+	}
 }
 
 // ensureAdminAddressPath sets the "--admin-address-path" flag so that it can be used in /ready checks. If a value

--- a/internal/envoy/shutdown.go
+++ b/internal/envoy/shutdown.go
@@ -59,9 +59,7 @@ func (r *Runtime) handleShutdown(ctx context.Context) {
 func (r *Runtime) interruptEnvoy() {
 	p := r.cmd.Process
 	moreos.Fprintf(r.Out, "sending interrupt to envoy (pid=%d)\n", p.Pid) //nolint
-	if err := moreos.Interrupt(p); err != nil {
-		moreos.Fprintf(r.Out, "warning: %s\n", err) //nolint
-	}
+	r.maybeWarn(moreos.Interrupt(p))
 }
 
 func (r *Runtime) archiveRunDir() error {

--- a/internal/moreos/testdata/fake_func-e.go
+++ b/internal/moreos/testdata/fake_func-e.go
@@ -50,7 +50,7 @@ func run(ctx context.Context, args []string) (err error) { //nolint:gocyclo
 
 	// Suppress any error and replace it with the envoy exit status when > 1
 	defer func() {
-		if cmd.ProcessState != nil && cmd.ProcessState.ExitCode() > 0 {
+		if cmd.ProcessState.ExitCode() > 0 {
 			if err != nil {
 				moreos.Fprintf(cmd.Stdout, "warning: %s\n", err) //nolint
 			}


### PR DESCRIPTION
This addresses some fuzz to make sure the comments don't lie. Notably,
this defers contexts the same way between fake and real. This also pulls
out handleShutdown to accent notes from #372