### PR TITLE
Pushes internal arm64 CentOS image and adds RATIONALE.md about Travis

### DIFF
--- a/.github/workflows/commit.yaml
+++ b/.github/workflows/commit.yaml
@@ -103,10 +103,8 @@ jobs:
           sudo timedatectl set-timezone America/Phoenix
           make test
 
-  # Github Action Runners don't support all operating systems we may need to test. Below ensures
-  # we run on the intended minimum platforms. Note: we also use Travis for arm64+ubuntu.
-  #
-  # Use only images from internal-images.yaml to avoid Docker rate limits and slow install steps.
+  # Github Action Runners doesn't support all operating systems and architectures we need to test.
+  # This adds CentOS+amd64 using docker. We use Travis for arm64. See RATIONALE.md
   test-e2e:
     name: "Run e2e tests via containers (${{ matrix.container }})"
     runs-on: ubuntu-latest
@@ -116,8 +114,8 @@ jobs:
     timeout-minutes: 90  # instead of 360 by default
     strategy:
       fail-fast: false  # don't fail fast as sometimes failures are operating system specific
-      matrix:
-        container: ["ghcr.io/tetratelabs/func-e-internal:centos8"]
+      matrix:  # only use images from internal-images.yaml. See RATIONALE.md
+        container: ["ghcr.io/${{ github.repository_owner }}/func-e-internal:centos8"]
 
     steps:
       - name: "Checkout"

--- a/.github/workflows/internal-images.yml
+++ b/.github/workflows/internal-images.yml
@@ -30,6 +30,19 @@ jobs:
             target_tag: centos8
     runs-on: ubuntu-latest
     steps:
+      # Same as doing this locally: echo "${GHCR_TOKEN}" | docker login ghcr.io -u "${GHCR_TOKEN}" --password-stdin
+      - name: Login into GitHub Container Registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          # GHCR_TOKEN=<hex token value>
+          #   - pushes Docker images to ghcr.io
+          #   - create via https://github.com/settings/tokens
+          #   - assign via https://github.com/organizations/tetratelabs/settings/secrets/actions
+          #   - needs repo:status, public_repo, write:packages, delete:packages
+          password: ${{ secrets.GHCR_TOKEN }}
+
       # We need QEMU and Buildx for multi-platform (amd64+arm64) image push. See RATIONALE.md
       - name: Setup QEMU
         uses: docker/setup-qemu-action@v1
@@ -50,11 +63,3 @@ jobs:
           context: .
           platforms: linux/amd64,linux/arm64  # arm64 is run only by Travis. See RATIONALE.md
           tags: ghcr.io/${{ github.repository_owner }}/func-e-internal:${{ matrix.target_tag }}
-          # Same as doing this locally: echo "${GHCR_TOKEN}" | docker login ghcr.io -u "${GHCR_TOKEN}" --password-stdin
-          # GHCR_TOKEN=<hex token value>
-          #   - pushes Docker images to ghcr.io
-          #   - create via https://github.com/settings/tokens
-          #   - assign via https://github.com/organizations/tetratelabs/settings/secrets/actions
-          #   - needs repo:status, public_repo, write:packages, delete:packages
-          secrets: |
-            GIT_AUTH_TOKEN=${{ secrets.GHCR_TOKEN }}

--- a/.github/workflows/internal-images.yml
+++ b/.github/workflows/internal-images.yml
@@ -2,7 +2,7 @@
 ---
 name: internal-images
 
-# Refresh the tags once a day
+# Refresh the tags once a day. This limits impact of rate-limited images. See RATIONALE.md
 on:
   schedule:
     - cron: "23 3 * * *"
@@ -24,29 +24,37 @@ jobs:
       matrix:
         # Be precise in tag versions to improve reproducibility
         include:
-          - dockerfile: |
+          - dockerfile: |  # Don't install golang as the version often changes
               FROM centos:8
               RUN yum install -y --quiet make which git gcc && yum clean all
             target_tag: centos8
     runs-on: ubuntu-latest
     steps:
-      # Same as doing this locally: echo "${GHCR_TOKEN}" | docker login ghcr.io -u "${GHCR_TOKEN}" --password-stdin
-      - name: Login into GitHub Container Registry
-        uses: docker/login-action@v1
+      # We need QEMU and Buildx for multi-platform (amd64+arm64) image push. See RATIONALE.md
+      - name: Setup QEMU
+        uses: docker/setup-qemu-action@v1
+
+      - name: Setup Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Write Dockerfile
+        run: |
+          cat > Dockerfile <<'EOF'
+          ${{ matrix.dockerfile }}
+          EOF
+
+      - name: Build and push
+        uses: docker/build-push-action@v2
         with:
-          registry: ghcr.io
-          username: ${{ github.repository_owner }}
+          push: true
+          context: .
+          platforms: linux/amd64,linux/arm64  # arm64 is run only by Travis. See RATIONALE.md
+          tags: ghcr.io/${{ github.repository_owner }}/func-e-internal:${{ matrix.target_tag }}
+          # Same as doing this locally: echo "${GHCR_TOKEN}" | docker login ghcr.io -u "${GHCR_TOKEN}" --password-stdin
           # GHCR_TOKEN=<hex token value>
           #   - pushes Docker images to ghcr.io
           #   - create via https://github.com/settings/tokens
           #   - assign via https://github.com/organizations/tetratelabs/settings/secrets/actions
           #   - needs repo:status, public_repo, write:packages, delete:packages
-          password: ${{ secrets.GHCR_TOKEN }}
-
-      - name: Build and push
-        run: |  # This will only push a single architecture, which is fine as we currently only support amd64
-          cat > Dockerfile <<'EOF'
-          ${{ matrix.dockerfile }}
-          EOF
-          docker build -t ghcr.io/tetratelabs/func-e-internal:${{ matrix.target_tag }} .
-          docker push ghcr.io/tetratelabs/func-e-internal:${{ matrix.target_tag }}
+          secrets: |
+            GIT_AUTH_TOKEN=${{ secrets.GHCR_TOKEN }}

--- a/RATIONALE.md
+++ b/RATIONALE.md
@@ -1,0 +1,25 @@
+# Notable rationale of func-e
+
+## Why do we use Travis and GitHub Actions instead of only GitHub Actions?
+We use Travis to run CentOS integration tests on arm64 until [GitHub Actions supports it](https://github.com/actions/virtual-environments/issues/2552).
+
+This is an alternative to using emulation instead. Using emulation (ex via `setup-qemu-action` and
+`setup-buildx-action`) re-introduces problems we eliminated with Travis. For example, not only would
+runners take longer to execute (as emulation is slower than native arch), but there is more setup,
+and that setup executes on every change. This setup takes time and uses rate-limited registries. It
+also introduces potential for compatibility issues when we move off Docker due to its recent
+[licensing changes](https://www.docker.com/pricing).
+
+It is true that Travis has a different syntax and that also could fail. However, the risk of
+failure is low. What we gain from running end-to-end or packaging tests on Travis is knowledge that
+we broke our [Makefile](Makefile) or that there's an unknown new dependency of Envoy® (such as a
+change to the floor version of glibc). While these are unlikely to occur, running tests are still
+important.
+
+The only place we use emulation is [publishing internal images](.github/workflows/internal-images.yml).
+This is done for convenience and occurs once per day, so duration and rate limiting effects are
+not important. If something breaks here, the existing images would become stale, so it isn't as
+much an emergency as if we put emulation in the critical path (ex in PR tests.)
+
+At the point when GitHub Actions supports free arm64 runners, we can simplify by removing Travis.
+Azure DevOps Pipelines already supports arm64, so it is possible GitHub Actions will in the future.


### PR DESCRIPTION
A lot of thought went into the decision of whether or not to use
emulation for arm64. However, this was spread out across discussions and
PRs, but not in the codebase. This adds a RATIONALE section with the
background, which is that this is temporary until GHA supports arm64.

Note, the same would apply if we start supporting s390x, except we don't
at the moment, which is why that isn't mentioned. s390x support would
need to happen first in Envoy.

Obviates #373