### PR TITLE
Removes go version maintenance

### DIFF
--- a/.github/workflows/commit.yaml
+++ b/.github/workflows/commit.yaml
@@ -4,8 +4,8 @@
 ---
 name: "build"
 
-env:  # As of 2021-08-05 images come with go 1.15 https://github.com/actions/virtual-environments/tree/main/images
-  GO_VERSION: "1.17.0"
+env:  # Update this prior to requiring a higher minor version in go.mod
+  GO_VERSION: "1.17"  # Latest patch
 
 on:
   push:  # We run tests on non-tagged pushes to master
@@ -123,7 +123,7 @@ jobs:
 
       - name: "Install Go"
         uses: actions/setup-go@v2
-        with:
+        with:  # TODO: refactor this as the image will already have go installed
           go-version: ${{ env.GO_VERSION }}
 
       - name: "Cache golang"

--- a/.github/workflows/internal-images.yml
+++ b/.github/workflows/internal-images.yml
@@ -28,6 +28,10 @@ jobs:
         include:
           # This installs the dependencies needed to build func-e including the latest patch of go
           # CentOS' root user shell is /bin/bash so go env is set via ~/.bashrc
+          #
+          # Note: This uses gimme so that we can install the latest patch of go without knowing what
+          # that is, or parsing it on our own. This is more flexible and removes update maintenance
+          # we'd have if we hard coded a specific patch. See https://github.com/travis-ci/gimme
           - dockerfile: |
               FROM centos:8
               RUN yum install -y --quiet make which git gcc && yum clean all && \

--- a/.github/workflows/internal-images.yml
+++ b/.github/workflows/internal-images.yml
@@ -8,6 +8,9 @@ on:
     - cron: "23 3 * * *"
   workflow_dispatch:  # Allows manual refresh
 
+env:  # Update this prior to requiring a higher minor version in go.mod
+  GO_VERSION: "1.17"  # Latest patch
+
 # This builds images and pushes them to ghcr.io/tetratelabs/func-e-internal:$tag
 # Using these in tests and as a parent (FROM) avoids docker.io rate-limits particularly on pull requests.
 #
@@ -15,7 +18,6 @@ on:
 # ```bash
 # $ docker run -ti -v $PWD:/func-e --rm centos:8
 # [root@d37da4601545 /]# cd /func-e
-# [root@d37da4601545 func-e]# eval "$(curl -sL https://raw.githubusercontent.com/travis-ci/gimme/master/gimme | GIMME_GO_VERSION=1.17 bash)"
 # now execute your setup commands!
 # ```
 jobs:
@@ -24,9 +26,13 @@ jobs:
       matrix:
         # Be precise in tag versions to improve reproducibility
         include:
-          - dockerfile: |  # Don't install golang as the version often changes
+          # This installs the dependencies needed to build func-e including the latest patch of go
+          - dockerfile: |
               FROM centos:8
-              RUN yum install -y --quiet make which git gcc && yum clean all
+              RUN yum install -y --quiet make which git gcc && yum clean all && \
+                  curl -sL https://raw.githubusercontent.com/travis-ci/gimme/master/gimme | GIMME_GO_VERSION=${{ env.GO_VERSION }}.x bash && \
+                  source ~/.gimme/envs/latest.env && \
+                  go version
             target_tag: centos8
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/internal-images.yml
+++ b/.github/workflows/internal-images.yml
@@ -27,12 +27,13 @@ jobs:
         # Be precise in tag versions to improve reproducibility
         include:
           # This installs the dependencies needed to build func-e including the latest patch of go
+          # CentOS' root user shell is /bin/bash so go env is set via ~/.bashrc
           - dockerfile: |
               FROM centos:8
               RUN yum install -y --quiet make which git gcc && yum clean all && \
                   curl -sL https://raw.githubusercontent.com/travis-ci/gimme/master/gimme | GIMME_GO_VERSION=${{ env.GO_VERSION }}.x bash && \
-                  source ~/.gimme/envs/latest.env && \
-                  go version
+                  cat ~/.gimme/envs/latest.env >> ~/.bashrc
+              ENTRYPOINT ["/bin/bash"]
             target_tag: centos8
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/msi.yaml
+++ b/.github/workflows/msi.yaml
@@ -4,8 +4,8 @@
 ---
 name: "msi"
 
-env:  # As of 2021-08-05 images come with go 1.15 https://github.com/actions/virtual-environments/tree/main/images
-  GO_VERSION: "1.17.0"
+env:  # Update this prior to requiring a higher minor version in go.mod
+  GO_VERSION: "1.17"  # Latest patch
 
 on:
   push:  # We run tests on non-tagged pushes to master

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -8,8 +8,8 @@ on:
   push:
     tags: 'v[0-9]+.[0-9]+.[0-9]+**'  # Ex. v0.2.0 v0.2.1-rc2
 
-env:  # As of 2021-08-05 images come with go 1.15 https://github.com/actions/virtual-environments/tree/main/images
-  GO_VERSION: "1.17.0"
+env:  # Update this prior to requiring a higher minor version in go.mod
+  GO_VERSION: "1.17"  # Latest patch
 
 defaults:
   run:  # use bash for all operating systems unless overridden

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,8 @@ group: edge  # required for arm64-graviton2
 virt: lxd  # faster starting
 language: go
 
-go:
-  - 1.17
+go:  # Use gimme expression to get latest patch. See https://github.com/travis-ci/gimme
+  - 1.17.x
 
 cache:
   directories: # ~/.func-e/versions is cached so that we only re-download once: for TestFuncEInstall

--- a/Makefile
+++ b/Makefile
@@ -149,20 +149,9 @@ lint:
          >./internal/version/last_known_envoy.txt
 	@printf "$(ansi_format_bright)" lint "ok"
 
-# Enforce go version matches what's in go.mod when running `make check` assuming the following:
-# * 'go version' returns output like "go version go1.16 darwin/amd64"
-# * go.mod contains a line like "go 1.16"
-expected_go_version_prefix := "go version go$(shell sed -ne '/^go /s/.* //gp' go.mod )"
-go_version := $(shell go version)
-
 # CI blocks merge until this passes. If this fails, run "make check" locally and commit the difference.
 # This formats code before running lint, as it is annoying to tell people to format first!
 check: ## Verify contents of last commit
-# case statement because /bin/sh cannot do prefix comparison, awk is awkward and assuming /bin/bash is brittle
-	@case "$(go_version)" in $(expected_go_version_prefix)* ) ;; * ) \
-		echo "Expected 'go version' to start with $(expected_go_version_prefix), but it didn't: $(go_version)"; \
-		exit 1; \
-	esac
 	@$(MAKE) lint
 	@$(MAKE) format
 	@# Make sure the check-in is clean


### PR DESCRIPTION
This removes the hard requirement to build with exactly the same version
of go as indicated in the go.mod file. This allows more flexibility when
new versions of go (such as 1.18) are released.

This also removes the requirement to track down to the patch of go.
Instead, this builds with the latest patch of go that's available at the
time.

Go versions aren't often released, but this removes maintenance each
time that happens. It also allows us to more easily cache golang
installs in our Docker image, and without tight coupling to what GitHub
actions uses.