### PR TITLE
Uses Docker build arg to set go version

### DIFF
--- a/.github/workflows/internal-images.yml
+++ b/.github/workflows/internal-images.yml
@@ -35,8 +35,9 @@ jobs:
           - dockerfile: |
               FROM centos:8
               RUN yum install -y --quiet make which git gcc && yum clean all
-              RUN curl -sL https://raw.githubusercontent.com/travis-ci/gimme/master/gimme | GIMME_GO_VERSION=1.17.x bash
-              RUN cat ~/.gimme/envs/latest.env >> ~/.bashrc
+              ARG GO_VERSION
+              RUN curl -sSL https://raw.githubusercontent.com/travis-ci/gimme/master/gimme | GIMME_GO_VERSION=$GO_VERSION.x bash && \
+                  cat ~/.gimme/envs/latest.env >> ~/.bashrc
               ENTRYPOINT ["/bin/bash"]
             target_tag: centos8
     runs-on: ubuntu-latest
@@ -72,5 +73,6 @@ jobs:
         with:
           push: true
           context: .
+          build-args: GO_VERSION=${{ env.GO_VERSION }}
           platforms: linux/amd64,linux/arm64  # arm64 is run only by Travis. See RATIONALE.md
           tags: ghcr.io/${{ github.repository_owner }}/func-e-internal:${{ matrix.target_tag }}


### PR DESCRIPTION
There's value in having all GitHub workflows being consistent in how
they declare the minor version of go we want. There's a strange nuance,
which is that GHA matrix variables cannot interpolate env variables.
Instead, this supplies the same value using a Docker build arg. Now, all
workflows that rely on go have a similar env header, which makes it
easier to update consistently, despite the inconsistency in how GHA
interpolates variables!
