### PR TITLE
Ensures Ubuntu runs the same version of go as CentOS

### DIFF
--- a/.github/workflows/commit.yaml
+++ b/.github/workflows/commit.yaml
@@ -4,12 +4,6 @@
 ---
 name: "build"
 
-# GOROOT_NAME resolves a GOROOT path corresponding to a major Golang release on the current runner.
-# Ex. Given GOROOT_NAME=GOROOT_1_17_X64, ${!GOROOT_NAME}=/opt/hostedtoolcache/go/1.17.1/x64
-# See https://github.com/actions/virtual-environments/blob/main/images/linux/Ubuntu2004-README.md#environment-variables-2
-env:
-  GOROOT_NAME: GOROOT_1_17_X64
-
 on:
   push:  # We run tests on non-tagged pushes to master
     tags: ''
@@ -57,32 +51,17 @@ jobs:
       - name: "Checkout"
         uses: actions/checkout@v2
 
-      # This sets the version-specific GOROOT env on macOS until actions/virtual-environments#4156
-      #
-      # This must happen before interpolating ${!GOROOT_NAME} on macOS
-      - name: "Set GOROOT_X64 env (macOS)"
-        if: runner.os == 'macOS'
-        run: |  # ex GOROOT_1_17_X64 -> 1.17
-          go_version=$(echo ${GOROOT_NAME//_/.}| cut -d. -f2,3)
-          go_root=$(ls -d /Users/runner/hostedtoolcache/go/${go_version}*/x64|sort -n|tail -1)
-          echo "${GOROOT_NAME}=${go_root}" >> $GITHUB_ENV
-
       - name: "Configure Go"
-        run: |  # This exports variables needed to run and cache a GOROOT set with ${!GOROOT_NAME}.
-          go_path=${!GOROOT_NAME}/bin
-          for var in GOROOT GOCACHE GOMODCACHE; do
-            echo ${var}=$(${go_path}/go env ${var}) >> $GITHUB_ENV
-          done
-          echo ${go_path} >> $GITHUB_PATH
+        run: .github/workflows/configure_go.sh
 
       - name: "Cache Go"
         uses: actions/cache@v2
         with:
-          path: |  # Cache downloaded go modules and the build cache (Makefile involves `go run`)
+          path: |  # Cache downloaded Go modules and the GOCACHE (to cache `go run` builds invoked by Makefile)
+            ~/go/pkg/mod
             ${{ env.GOCACHE }}
-            ${{ env.GOMODCACHE }}
-          key: test-${{ runner.os }}-${{ env.GOROOT_NAME }}-go-${{ hashFiles('go.sum', 'Makefile') }}
-          restore-keys: test-${{ runner.os }}-${{ env.GOROOT_NAME }}-go-
+          key: test-${{ runner.os }}-${{ env.GO_VERSION }}-go-${{ hashFiles('go.sum', 'Makefile') }}
+          restore-keys: test-${{ runner.os }}-${{ env.GO_VERSION }}-go-
 
       - name: "Cache Envoy binaries"
         uses: actions/cache@v2

--- a/.github/workflows/commit.yaml
+++ b/.github/workflows/commit.yaml
@@ -4,8 +4,11 @@
 ---
 name: "build"
 
-env:  # Update this prior to requiring a higher minor version in go.mod
-  GO_VERSION: "1.17"  # Latest patch
+# GOROOT_NAME resolves a GOROOT path corresponding to a major Golang release on the current runner.
+# Ex. Given GOROOT_NAME=GOROOT_1_17_X64, ${!GOROOT_NAME}=/opt/hostedtoolcache/go/1.17.1/x64
+# See https://github.com/actions/virtual-environments/blob/main/images/linux/Ubuntu2004-README.md#environment-variables-2
+env:
+  GOROOT_NAME: GOROOT_1_17_X64
 
 on:
   push:  # We run tests on non-tagged pushes to master
@@ -54,19 +57,32 @@ jobs:
       - name: "Checkout"
         uses: actions/checkout@v2
 
-      - name: "Install Go"
-        uses: actions/setup-go@v2
-        with:
-          go-version: ${{ env.GO_VERSION }}
+      # This sets the version-specific GOROOT env on macOS until actions/virtual-environments#4156
+      #
+      # This must happen before interpolating ${!GOROOT_NAME} on macOS
+      - name: "Set GOROOT_X64 env (macOS)"
+        if: runner.os == 'macOS'
+        run: |  # ex GOROOT_1_17_X64 -> 1.17
+          go_version=$(echo ${GOROOT_NAME//_/.}| cut -d. -f2,3)
+          go_root=$(ls -d /Users/runner/hostedtoolcache/go/${go_version}*/x64|sort -n|tail -1)
+          echo "${GOROOT_NAME}=${go_root}" >> $GITHUB_ENV
 
-      - name: "Cache golang"
+      - name: "Configure Go"
+        run: |  # This exports variables needed to run and cache a GOROOT set with ${!GOROOT_NAME}.
+          go_path=${!GOROOT_NAME}/bin
+          for var in GOROOT GOCACHE GOMODCACHE; do
+            echo ${var}=$(${go_path}/go env ${var}) >> $GITHUB_ENV
+          done
+          echo ${go_path} >> $GITHUB_PATH
+
+      - name: "Cache Go"
         uses: actions/cache@v2
         with:
-          path: |  # TODO: go build cache if we care, noting it is OS-specific
-            ~/go/pkg/mod
-          # Makefile contains go run statements which affect the build cache
-          key: test-${{ runner.os }}-${{ env.GO_VERSION }}-go-${{ hashFiles('go.sum', 'Makefile') }}
-          restore-keys: test-${{ runner.os }}-${{ env.GO_VERSION }}-go-
+          path: |  # Cache downloaded go modules and the build cache (Makefile involves `go run`)
+            ${{ env.GOCACHE }}
+            ${{ env.GOMODCACHE }}
+          key: test-${{ runner.os }}-${{ env.GOROOT_NAME }}-go-${{ hashFiles('go.sum', 'Makefile') }}
+          restore-keys: test-${{ runner.os }}-${{ env.GOROOT_NAME }}-go-
 
       - name: "Cache Envoy binaries"
         uses: actions/cache@v2
@@ -104,7 +120,7 @@ jobs:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         run: bash <(curl -s https://codecov.io/bash)
 
-      - name: "Run unit tests in a different timezone" # https://github.com/tetratelabs/func-e/issues/303.
+      - name: "Run unit tests in a different timezone"  # https://github.com/tetratelabs/func-e/issues/303.
         if: runner.os == 'Linux'
         run: |
           sudo timedatectl set-timezone America/Phoenix

--- a/.github/workflows/configure_go.sh
+++ b/.github/workflows/configure_go.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+#
+# This configures Go according to go.mod, choosing the a GOROOT based on existing variables.
+# For example, if go.mod includes "go 1.17", GOROOT=${GOROOT_1_17} or ${GOROOT_1_17_X64}
+#
+# Variables such as GOROOT_1_17_X64 are defined by GitHub Actions runners. So, this will not
+# result in downloading or installing anything not already there.
+#
+# Notes:
+# * In GitHub, these evaluate to ${RUNNER_TOOL_CACHE}/go/${GO_VERSION}*/x64
+#   * RUNNER_TOOL_CACHE lags Go releases by 1-2 weeks https://github.com/actions/virtual-environments
+# * To simulate GitHub for testing, set GITHUB_ENV and GITHUB_PATH to temporary files
+#   * Ex. `GITHUB_ENV=/tmp/test-env GITHUB_PATH=/tmp/test-path .github/workflows/configure_go.sh
+# * This uses bash because we need indirect variable expansion and GHA runners all have bash.
+set -uex pipefail
+
+go_version=$(sed -n 's/^go //gp' go.mod)
+echo GO_VERSION="${go_version}" >> "${GITHUB_ENV}"
+
+# Match last exported GOROOT variable name that includes the version we want. Ex. GOROOT_1_17_X64
+goroot_name=$(env|grep "^GOROOT_${go_version//./_}"| sed 's/=.*//g'|sort -n|tail -1)
+
+# Remove this if/else after actions/virtual-environments#4156 is solved
+if [ -n "${goroot_name}" ]; then
+  go_root=${!goroot_name}
+else
+  # This works around missing variables on macOS via naming convention.
+  # Ex. /Users/runner/hostedtoolcache/go/1.17.1/x64
+  go_root=$(ls -d "${RUNNER_TOOL_CACHE}"/go/"${go_version}"*/x64|sort -n|tail -1)
+fi
+
+# Ensure go works
+go="${go_root}/bin/go"
+${go} version >/dev/null
+
+# Setup the GOROOT
+echo GOROOT="${go_root}" >> "${GITHUB_ENV}"
+echo "${go_root}/bin" >>"${GITHUB_PATH}"
+
+# Add the OS-specific GOCACHE (build cache) variable for actions/cache
+echo GOCACHE=$(${go} env GOCACHE) >> "${GITHUB_ENV}"

--- a/.github/workflows/internal-images.yml
+++ b/.github/workflows/internal-images.yml
@@ -8,12 +8,6 @@ on:
     - cron: "23 3 * * *"
   workflow_dispatch:  # Allows manual refresh
 
-# GOROOT_NAME resolves a GOROOT path corresponding to a major Golang release on the current runner.
-# Ex. Given GOROOT_NAME=GOROOT_1_17_X64, ${!GOROOT_NAME}=/opt/hostedtoolcache/go/1.17.1/x64
-# See https://github.com/actions/virtual-environments/blob/main/images/linux/Ubuntu2004-README.md#environment-variables-2
-env:
-  GOROOT_NAME: GOROOT_1_17_X64
-
 # This builds images and pushes them to ghcr.io/tetratelabs/func-e-internal:$tag
 # Using these in tests and as a parent (FROM) avoids docker.io rate-limits particularly on pull requests.
 #
@@ -48,7 +42,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # Same as doing this locally: echo "${GHCR_TOKEN}" | docker login ghcr.io -u "${GHCR_TOKEN}" --password-stdin
-      - name: Login into GitHub Container Registry
+      - name: "Login into GitHub Container Registry"
         uses: docker/login-action@v1
         with:
           registry: ghcr.io
@@ -61,28 +55,30 @@ jobs:
           password: ${{ secrets.GHCR_TOKEN }}
 
       # We need QEMU and Buildx for multi-platform (amd64+arm64) image push. See RATIONALE.md
-      - name: Setup QEMU
+      - name: "Setup QEMU"
         uses: docker/setup-qemu-action@v1
 
-      - name: Setup Buildx
+      - name: "Setup Buildx"
         uses: docker/setup-buildx-action@v1
 
-      # This resolves GOROOT_NAME (ex GOROOT_1_17_X64) into GO_MINOR_REVISION (ex 1.17.1), by
-      # parsing the directory path GOROOT_NAME evaluates to.
-      #
-      # Ex. Given ${!GOROOT_NAME}=/opt/hostedtoolcache/go/1.17.1/x64 -> GO_MINOR_REVISION=1.17.1
-      - name: Export Go minor revision
-        run: |
-          rev=$(echo ${!GOROOT_NAME}|cut -d/ -f5)
+      - name: "Checkout"
+        uses: actions/checkout@v2
+
+      - name: "Configure Go"
+        run: .github/workflows/configure_go.sh
+
+      - name: "Export Go minor revision"
+        run: |  # Ex. GOROOT=/opt/hostedtoolcache/go/1.17.1/x64 -> GO_MINOR_REVISION=1.17.1
+          rev=$(echo ${GOROOT}|cut -d/ -f5)
           echo "GO_MINOR_REVISION=${rev}" >> $GITHUB_ENV
 
-      - name: Write Dockerfile
+      - name: "Write Dockerfile"
         run: |
           cat > Dockerfile <<'EOF'
           ${{ matrix.dockerfile }}
           EOF
 
-      - name: Build and push
+      - name: "Build and push"
         uses: docker/build-push-action@v2
         with:
           push: true

--- a/.github/workflows/msi.yaml
+++ b/.github/workflows/msi.yaml
@@ -4,8 +4,11 @@
 ---
 name: "msi"
 
-env:  # Update this prior to requiring a higher minor version in go.mod
-  GO_VERSION: "1.17"  # Latest patch
+# GOROOT_NAME resolves a GOROOT path corresponding to a major Golang release on the current runner.
+# Ex. Given GOROOT_NAME=GOROOT_1_17_X64, ${!GOROOT_NAME}=/Users/runner/hostedtoolcache/go/1.17.1/x64
+# See https://github.com/actions/virtual-environments/blob/main/images/linux/Ubuntu2004-README.md#environment-variables-2
+env:
+  GOROOT_NAME: GOROOT_1_17_X64
 
 on:
   push:  # We run tests on non-tagged pushes to master
@@ -58,25 +61,38 @@ jobs:
     steps:
       - name: "Setup msitools, wixtoolset, osslsigncode"
         run: ${{ matrix.setup }}
-        env: # `gh` requires auth even on public releases
+        env:  # `gh` requires auth even on public releases
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: "Checkout"
         uses: actions/checkout@v2
 
-      - name: "Install Go"
-        uses: actions/setup-go@v2
-        with:
-          go-version: ${{ env.GO_VERSION }}
+      # This sets the version-specific GOROOT env on macOS until actions/virtual-environments#4156
+      #
+      # This must happen before interpolating ${!GOROOT_NAME} on macOS
+      - name: "Set GOROOT_X64 env (macOS)"
+        if: runner.os == 'macOS'
+        run: |  # ex GOROOT_1_17_X64 -> 1.17
+          go_version=$(echo ${GOROOT_NAME//_/.}| cut -d. -f2,3)
+          go_root=$(ls -d /Users/runner/hostedtoolcache/go/${go_version}*/x64|sort -n|tail -1)
+          echo "${GOROOT_NAME}=${go_root}" >> $GITHUB_ENV
 
-      - name: "Cache golang"
+      - name: "Configure Go"
+        run: |  # This exports variables needed to run and cache a GOROOT set with ${!GOROOT_NAME}.
+          go_path=${!GOROOT_NAME}/bin
+          for var in GOROOT GOCACHE GOMODCACHE; do
+            echo ${var}=$(${go_path}/go env ${var}) >> $GITHUB_ENV
+          done
+          echo ${go_path} >> $GITHUB_PATH
+
+      - name: "Cache Go"
         uses: actions/cache@v2
         with:
-          path: |  # TODO: go build cache if we care, noting it is OS-specific
-            ~/go/pkg/mod
-          # Makefile contains go run statements which affect the build cache
-          key: test-${{ runner.os }}-${{ env.GO_VERSION }}-go-${{ hashFiles('go.sum', 'Makefile') }}
-          restore-keys: test-${{ runner.os }}-${{ env.GO_VERSION }}-go-
+          path: |  # Cache downloaded go modules and the build cache (Makefile involves `go run`)
+            ${{ env.GOCACHE }}
+            ${{ env.GOMODCACHE }}
+          key: test-${{ runner.os }}-${{ env.GOROOT_NAME }}-go-${{ hashFiles('go.sum', 'Makefile') }}
+          restore-keys: test-${{ runner.os }}-${{ env.GOROOT_NAME }}-go-
 
       - name: "Build Windows Installer (MSI)"
         run: make dist

--- a/.github/workflows/msi.yaml
+++ b/.github/workflows/msi.yaml
@@ -4,12 +4,6 @@
 ---
 name: "msi"
 
-# GOROOT_NAME resolves a GOROOT path corresponding to a major Golang release on the current runner.
-# Ex. Given GOROOT_NAME=GOROOT_1_17_X64, ${!GOROOT_NAME}=/Users/runner/hostedtoolcache/go/1.17.1/x64
-# See https://github.com/actions/virtual-environments/blob/main/images/linux/Ubuntu2004-README.md#environment-variables-2
-env:
-  GOROOT_NAME: GOROOT_1_17_X64
-
 on:
   push:  # We run tests on non-tagged pushes to master
     tags: ''
@@ -67,32 +61,17 @@ jobs:
       - name: "Checkout"
         uses: actions/checkout@v2
 
-      # This sets the version-specific GOROOT env on macOS until actions/virtual-environments#4156
-      #
-      # This must happen before interpolating ${!GOROOT_NAME} on macOS
-      - name: "Set GOROOT_X64 env (macOS)"
-        if: runner.os == 'macOS'
-        run: |  # ex GOROOT_1_17_X64 -> 1.17
-          go_version=$(echo ${GOROOT_NAME//_/.}| cut -d. -f2,3)
-          go_root=$(ls -d /Users/runner/hostedtoolcache/go/${go_version}*/x64|sort -n|tail -1)
-          echo "${GOROOT_NAME}=${go_root}" >> $GITHUB_ENV
-
       - name: "Configure Go"
-        run: |  # This exports variables needed to run and cache a GOROOT set with ${!GOROOT_NAME}.
-          go_path=${!GOROOT_NAME}/bin
-          for var in GOROOT GOCACHE GOMODCACHE; do
-            echo ${var}=$(${go_path}/go env ${var}) >> $GITHUB_ENV
-          done
-          echo ${go_path} >> $GITHUB_PATH
+        run: .github/workflows/configure_go.sh
 
       - name: "Cache Go"
         uses: actions/cache@v2
         with:
-          path: |  # Cache downloaded go modules and the build cache (Makefile involves `go run`)
+          path: |  # Cache downloaded Go modules and the GOCACHE (to cache `go run` builds invoked by Makefile)
+            ~/go/pkg/mod
             ${{ env.GOCACHE }}
-            ${{ env.GOMODCACHE }}
-          key: test-${{ runner.os }}-${{ env.GOROOT_NAME }}-go-${{ hashFiles('go.sum', 'Makefile') }}
-          restore-keys: test-${{ runner.os }}-${{ env.GOROOT_NAME }}-go-
+          key: test-${{ runner.os }}-${{ env.GO_VERSION }}-go-${{ hashFiles('go.sum', 'Makefile') }}
+          restore-keys: test-${{ runner.os }}-${{ env.GO_VERSION }}-go-
 
       - name: "Build Windows Installer (MSI)"
         run: make dist

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -23,9 +23,7 @@ jobs:
           fetch-depth: 0
 
       - name: "Configure Go"
-        run: |  # We don't use actions/cache on release, so don't need to export GOMODCACHE as a variable.
-          echo "GOROOT=${!GOROOT_NAME}" >> $GITHUB_ENV
-          echo "${!GOROOT_NAME}/bin" >> $GITHUB_PATH
+        run: .github/workflows/configure_go.sh
 
       - name: "Download Windows code signing certificate"
         id: p12
@@ -79,20 +77,8 @@ jobs:
       - name: "Checkout"
         uses: actions/checkout@v2
 
-      # This sets the version-specific GOROOT env on macOS until actions/virtual-environments#4156
-      #
-      # This must happen before interpolating ${!GOROOT_NAME} on macOS
-      - name: "Set GOROOT_X64 env (macOS)"
-        if: runner.os == 'macOS'
-        run: |  # ex GOROOT_1_17_X64 -> 1.17
-          go_version=$(echo ${GOROOT_NAME//_/.}| cut -d. -f2,3)
-          go_root=$(ls -d /Users/runner/hostedtoolcache/go/${go_version}*/x64|sort -n|tail -1)
-          echo "${GOROOT_NAME}=${go_root}" >> $GITHUB_ENV
-
       - name: "Configure Go"
-        run: |  # We don't use actions/cache on release, so don't need to export GOMODCACHE as a variable.
-          echo "GOROOT=${!GOROOT_NAME}" >> $GITHUB_ENV
-          echo "${!GOROOT_NAME}/bin" >> $GITHUB_PATH
+        run: .github/workflows/configure_go.sh
 
       - name: "Extract `func-e` binary from GitHub release assets"
         id: download  # allows variables like ${{ steps.download.outputs.X }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -8,12 +8,6 @@ on:
   push:
     tags: 'v[0-9]+.[0-9]+.[0-9]+**'  # Ex. v0.2.0 v0.2.1-rc2
 
-# GOROOT_NAME resolves a GOROOT path corresponding to a major Golang release on the current runner.
-# Ex. Given GOROOT_NAME=GOROOT_1_17_X64, ${!GOROOT_NAME}=/opt/hostedtoolcache/go/1.17.1/x64
-# See https://github.com/actions/virtual-environments/blob/main/images/linux/Ubuntu2004-README.md#environment-variables-2
-env:
-  GOROOT_NAME: GOROOT_1_17_X64
-
 defaults:
   run:  # use bash for all operating systems unless overridden
     shell: bash

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -8,8 +8,11 @@ on:
   push:
     tags: 'v[0-9]+.[0-9]+.[0-9]+**'  # Ex. v0.2.0 v0.2.1-rc2
 
-env:  # Update this prior to requiring a higher minor version in go.mod
-  GO_VERSION: "1.17"  # Latest patch
+# GOROOT_NAME resolves a GOROOT path corresponding to a major Golang release on the current runner.
+# Ex. Given GOROOT_NAME=GOROOT_1_17_X64, ${!GOROOT_NAME}=/opt/hostedtoolcache/go/1.17.1/x64
+# See https://github.com/actions/virtual-environments/blob/main/images/linux/Ubuntu2004-README.md#environment-variables-2
+env:
+  GOROOT_NAME: GOROOT_1_17_X64
 
 defaults:
   run:  # use bash for all operating systems unless overridden
@@ -25,10 +28,10 @@ jobs:
         with:  # fetch all history for all tags and branches (needed for changelog)
           fetch-depth: 0
 
-      - name: "Set up Go"
-        uses: actions/setup-go@v2
-        with:
-          go-version: ${{ env.GO_VERSION }}
+      - name: "Configure Go"
+        run: |  # We don't use actions/cache on release, so don't need to export cache variables.
+          echo "GOROOT=${!GOROOT_NAME}" >> $GITHUB_ENV
+          echo "${!GOROOT_NAME}/bin" >> $GITHUB_PATH
 
       - name: "Download Windows code signing certificate"
         id: p12
@@ -82,10 +85,20 @@ jobs:
       - name: "Checkout"
         uses: actions/checkout@v2
 
-      - name: "Install Go"
-        uses: actions/setup-go@v2
-        with:
-          go-version: ${{ env.GO_VERSION }}
+      # This sets the version-specific GOROOT env on macOS until actions/virtual-environments#4156
+      #
+      # This must happen before interpolating ${!GOROOT_NAME} on macOS
+      - name: "Set GOROOT_X64 env (macOS)"
+        if: runner.os == 'macOS'
+        run: |  # ex GOROOT_1_17_X64 -> 1.17
+          go_version=$(echo ${GOROOT_NAME//_/.}| cut -d. -f2,3)
+          go_root=$(ls -d /Users/runner/hostedtoolcache/go/${go_version}*/x64|sort -n|tail -1)
+          echo "${GOROOT_NAME}=${go_root}" >> $GITHUB_ENV
+
+      - name: "Configure Go"
+        run: |  # We don't use actions/cache on release, so don't need to export cache variables.
+          echo "GOROOT=${!GOROOT_NAME}" >> $GITHUB_ENV
+          echo "${!GOROOT_NAME}/bin" >> $GITHUB_PATH
 
       - name: "Extract `func-e` binary from GitHub release assets"
         id: download  # allows variables like ${{ steps.download.outputs.X }}
@@ -108,4 +121,3 @@ jobs:
         shell: cmd
         env:  # use the stashed msi name instead of parsing it
           MSI_FILE: ${{ steps.download.outputs.msi }}
-

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -29,7 +29,7 @@ jobs:
           fetch-depth: 0
 
       - name: "Configure Go"
-        run: |  # We don't use actions/cache on release, so don't need to export cache variables.
+        run: |  # We don't use actions/cache on release, so don't need to export GOMODCACHE as a variable.
           echo "GOROOT=${!GOROOT_NAME}" >> $GITHUB_ENV
           echo "${!GOROOT_NAME}/bin" >> $GITHUB_PATH
 
@@ -96,7 +96,7 @@ jobs:
           echo "${GOROOT_NAME}=${go_root}" >> $GITHUB_ENV
 
       - name: "Configure Go"
-        run: |  # We don't use actions/cache on release, so don't need to export cache variables.
+        run: |  # We don't use actions/cache on release, so don't need to export GOMODCACHE as a variable.
           echo "GOROOT=${!GOROOT_NAME}" >> $GITHUB_ENV
           echo "${!GOROOT_NAME}/bin" >> $GITHUB_PATH
 


### PR DESCRIPTION
This avoids any version differences between running e2e tests via Docker
(ex for CentOS) vs a normal run (Ubuntu, MacOS, etc). It accomplishes
this by using the built-in GOROOT variable.

go.mod controls which GOROOT is used, and in doing so, this removes
maintenance.

This includes a temporary workaround because MacOS does not have the
same variable as Windows and Ubuntu. Once the below is solved, we can
simply delete the workaround.

https://github.com/actions/virtual-environments/issues/4156