### PR TITLE
Detects GOROOT for go.mod using make

### DIFF
--- a/.github/workflows/commit.yaml
+++ b/.github/workflows/commit.yaml
@@ -56,7 +56,7 @@ jobs:
         with:
           path: ~/go/pkg/mod
           # go.mod for go release version, go.sum for modules used, and Tools.mk for 'go run' tools
-          key: test-${{ runner.os }}-go-${{ hashFiles('go.mod', go.sum', 'Tools.mk') }}
+          key: test-${{ runner.os }}-go-${{ hashFiles('go.mod', 'go.sum', 'Tools.mk') }}
           restore-keys: test-${{ runner.os }}-go-
 
       - name: "Cache Envoy binaries"

--- a/.github/workflows/commit.yaml
+++ b/.github/workflows/commit.yaml
@@ -51,17 +51,15 @@ jobs:
       - name: "Checkout"
         uses: actions/checkout@v2
 
-      - name: "Configure Go"
-        run: .github/workflows/configure_go.sh
+      - name: "Detect Go Release"  # only used for "Cache Go"
+        run: echo GO_RELEASE=$(sed -n 's/^go //gp' go.mod) >> "${GITHUB_ENV}"
 
       - name: "Cache Go"
         uses: actions/cache@v2
         with:
-          path: |  # Cache downloaded Go modules and the GOCACHE (to cache `go run` builds invoked by Makefile)
-            ~/go/pkg/mod
-            ${{ env.GOCACHE }}
-          key: test-${{ runner.os }}-${{ env.GO_VERSION }}-go-${{ hashFiles('go.sum', 'Makefile') }}
-          restore-keys: test-${{ runner.os }}-${{ env.GO_VERSION }}-go-
+          path: ~/go/pkg/mod
+          key: test-${{ runner.os }}-${{ env.GO_RELEASE }}-go-${{ hashFiles('go.sum', 'Tools.mk') }}
+          restore-keys: test-${{ runner.os }}-${{ env.GO_RELEASE }}-go-
 
       - name: "Cache Envoy binaries"
         uses: actions/cache@v2

--- a/.github/workflows/commit.yaml
+++ b/.github/workflows/commit.yaml
@@ -51,15 +51,13 @@ jobs:
       - name: "Checkout"
         uses: actions/checkout@v2
 
-      - name: "Detect Go Release"  # only used for "Cache Go"
-        run: echo GO_RELEASE=$(sed -n 's/^go //gp' go.mod) >> "${GITHUB_ENV}"
-
       - name: "Cache Go"
         uses: actions/cache@v2
         with:
           path: ~/go/pkg/mod
-          key: test-${{ runner.os }}-${{ env.GO_RELEASE }}-go-${{ hashFiles('go.sum', 'Tools.mk') }}
-          restore-keys: test-${{ runner.os }}-${{ env.GO_RELEASE }}-go-
+          # go.mod for go release version, go.sum for modules used, and Tools.mk for 'go run' tools
+          key: test-${{ runner.os }}-go-${{ hashFiles('go.mod', go.sum', 'Tools.mk') }}
+          restore-keys: test-${{ runner.os }}-go-
 
       - name: "Cache Envoy binaries"
         uses: actions/cache@v2

--- a/.github/workflows/configure_go.sh
+++ b/.github/workflows/configure_go.sh
@@ -7,18 +7,18 @@
 # result in downloading or installing anything not already there.
 #
 # Notes:
-# * In GitHub, these evaluate to ${RUNNER_TOOL_CACHE}/go/${GO_VERSION}*/x64
+# * In GitHub, these evaluate to ${RUNNER_TOOL_CACHE}/go/${GO_RELEASE}*/x64
 #   * RUNNER_TOOL_CACHE lags Go releases by 1-2 weeks https://github.com/actions/virtual-environments
 # * To simulate GitHub for testing, set GITHUB_ENV and GITHUB_PATH to temporary files
 #   * Ex. `GITHUB_ENV=/tmp/test-env GITHUB_PATH=/tmp/test-path .github/workflows/configure_go.sh
 # * This uses bash because we need indirect variable expansion and GHA runners all have bash.
 set -uex pipefail
 
-go_version=$(sed -n 's/^go //gp' go.mod)
-echo GO_VERSION="${go_version}" >> "${GITHUB_ENV}"
+go_release=$(sed -n 's/^go //gp' go.mod)
+echo GO_RELEASE="${go_release}" >> "${GITHUB_ENV}"
 
 # Match last exported GOROOT variable name that includes the version we want. Ex. GOROOT_1_17_X64
-goroot_name=$(env|grep "^GOROOT_${go_version//./_}"| sed 's/=.*//g'|sort -n|tail -1)
+goroot_name=$(env|grep "^GOROOT_${go_release//./_}"| sed 's/=.*//g'|sort -n|tail -1)
 
 # Remove this if/else after actions/virtual-environments#4156 is solved
 if [ -n "${goroot_name}" ]; then
@@ -26,7 +26,7 @@ if [ -n "${goroot_name}" ]; then
 else
   # This works around missing variables on macOS via naming convention.
   # Ex. /Users/runner/hostedtoolcache/go/1.17.1/x64
-  go_root=$(ls -d "${RUNNER_TOOL_CACHE}"/go/"${go_version}"*/x64|sort -n|tail -1)
+  go_root=$(ls -d "${RUNNER_TOOL_CACHE}"/go/"${go_release}"*/x64|sort -n|tail -1)
 fi
 
 # Ensure go works
@@ -36,6 +36,3 @@ ${go} version >/dev/null
 # Setup the GOROOT
 echo GOROOT="${go_root}" >> "${GITHUB_ENV}"
 echo "${go_root}/bin" >>"${GITHUB_PATH}"
-
-# Add the OS-specific GOCACHE (build cache) variable for actions/cache
-echo GOCACHE=$(${go} env GOCACHE) >> "${GITHUB_ENV}"

--- a/.github/workflows/msi.yaml
+++ b/.github/workflows/msi.yaml
@@ -66,7 +66,7 @@ jobs:
         with:
           path: ~/go/pkg/mod
           # go.mod for go release version, go.sum for modules used, and Tools.mk for 'go run' tools
-          key: test-${{ runner.os }}-go-${{ hashFiles('go.mod', go.sum', 'Tools.mk') }}
+          key: test-${{ runner.os }}-go-${{ hashFiles('go.mod', 'go.sum', 'Tools.mk') }}
           restore-keys: test-${{ runner.os }}-go-
 
       - name: "Build Windows Installer (MSI)"

--- a/.github/workflows/msi.yaml
+++ b/.github/workflows/msi.yaml
@@ -61,15 +61,13 @@ jobs:
       - name: "Checkout"
         uses: actions/checkout@v2
 
-      - name: "Detect Go Release"  # only used for "Cache Go"
-        run: echo GO_RELEASE=$(sed -n 's/^go //gp' go.mod) >> "${GITHUB_ENV}"
-
       - name: "Cache Go"
         uses: actions/cache@v2
         with:
           path: ~/go/pkg/mod
-          key: test-${{ runner.os }}-${{ env.GO_RELEASE }}-go-${{ hashFiles('go.sum', 'Tools.mk') }}
-          restore-keys: test-${{ runner.os }}-${{ env.GO_RELEASE }}-go-
+          # go.mod for go release version, go.sum for modules used, and Tools.mk for 'go run' tools
+          key: test-${{ runner.os }}-go-${{ hashFiles('go.mod', go.sum', 'Tools.mk') }}
+          restore-keys: test-${{ runner.os }}-go-
 
       - name: "Build Windows Installer (MSI)"
         run: make dist

--- a/.github/workflows/msi.yaml
+++ b/.github/workflows/msi.yaml
@@ -61,17 +61,15 @@ jobs:
       - name: "Checkout"
         uses: actions/checkout@v2
 
-      - name: "Configure Go"
-        run: .github/workflows/configure_go.sh
+      - name: "Detect Go Release"  # only used for "Cache Go"
+        run: echo GO_RELEASE=$(sed -n 's/^go //gp' go.mod) >> "${GITHUB_ENV}"
 
       - name: "Cache Go"
         uses: actions/cache@v2
         with:
-          path: |  # Cache downloaded Go modules and the GOCACHE (to cache `go run` builds invoked by Makefile)
-            ~/go/pkg/mod
-            ${{ env.GOCACHE }}
-          key: test-${{ runner.os }}-${{ env.GO_VERSION }}-go-${{ hashFiles('go.sum', 'Makefile') }}
-          restore-keys: test-${{ runner.os }}-${{ env.GO_VERSION }}-go-
+          path: ~/go/pkg/mod
+          key: test-${{ runner.os }}-${{ env.GO_RELEASE }}-go-${{ hashFiles('go.sum', 'Tools.mk') }}
+          restore-keys: test-${{ runner.os }}-${{ env.GO_RELEASE }}-go-
 
       - name: "Build Windows Installer (MSI)"
         run: make dist

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -22,9 +22,6 @@ jobs:
         with:  # fetch all history for all tags and branches (needed for changelog)
           fetch-depth: 0
 
-      - name: "Configure Go"
-        run: .github/workflows/configure_go.sh
-
       - name: "Download Windows code signing certificate"
         id: p12
         uses: timheuer/base64-to-file@v1
@@ -77,9 +74,6 @@ jobs:
       - name: "Checkout"
         uses: actions/checkout@v2
 
-      - name: "Configure Go"
-        run: .github/workflows/configure_go.sh
-
       - name: "Extract `func-e` binary from GitHub release assets"
         id: download  # allows variables like ${{ steps.download.outputs.X }}
         run: |
@@ -89,7 +83,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: "Run e2e tests using draft `func-e` binary"
-        run: go test -parallel 1 -v -failfast ./e2e
+        run: E2E_FUNC_E_PATH=. make e2e
 
       # This only checks the installer when built on Windows as it is simpler than switching OS.
       # refreshenv is from choco, and lets you reload ENV variables (used here for PATH).

--- a/.licenserignore
+++ b/.licenserignore
@@ -31,3 +31,4 @@ site/
 *.ps1
 *.cmd
 .mailmap
+Tools.mk

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,10 +30,10 @@ before_install: |  # Prevent test build of a documentation or GitHub Actions onl
 env:  # CENTOS_IMAGE was built by internal-images.yaml; E2E_FUNC_E_PATH was built via `make e2e`
   global:
     - CENTOS_IMAGE=ghcr.io/tetratelabs/func-e-internal:centos8
-    - E2E_FUNC_E_PATH=build/func-e_linux_arm64/func-e
+    - E2E_FUNC_E_PATH=build/func-e_linux_arm64/
 
 script:
   # Run e2e tests using the `func-e` binary (Ubuntu)
   - make e2e
   # Run e2e tests using the `func-e` binary (CentOS)
-  - docker run -v $HOME/.func-e:/root/.func-e -v $PWD:/func-e --rm ${CENTOS_IMAGE} -c "cd /func-e; make -o ${E2E_FUNC_E_PATH} e2e"
+  - docker run -v $HOME/.func-e:/root/.func-e -v $PWD:/func-e --rm ${CENTOS_IMAGE} -c "cd /func-e; make -o ${E2E_FUNC_E_PATH}/func-e e2e"

--- a/Makefile
+++ b/Makefile
@@ -22,13 +22,18 @@ dist_dir  := dist
 go_release           := $(shell sed -ne 's/^go //gp' go.mod)
 # https://github.com/actions/runner/blob/master/src/Runner.Common/Constants.cs
 github_runner_arch   := $(if $(findstring $(shell uname -m),x86_64),X64,ARM64)
-goroot_github_env    := $(GOROOT_$(subst .,_,$(go_release))_$(github_runner_arch))
+github_goroot_name   := GOROOT_$(subst .,_,$(go_release))_$(github_runner_arch)
+github_goroot_val    := $(value $(github_goroot_name))
 # This works around missing variables on macOS via naming convention.
 # Ex. /Users/runner/hostedtoolcache/go/1.17.1/x64
 # Remove this after actions/virtual-environments#4156 is solved.
-goroot_github_cache  := $(lastword $(shell ls -d $(RUNNER_TOOL_CACHE)/go/$(go_release)*/$(github_runner_arch) 2>/dev/null))
+github_goroot_cache  := $(lastword $(shell ls -d $(RUNNER_TOOL_CACHE)/go/$(go_release)*/$(github_runner_arch) 2>/dev/null))
 goroot_path          := $(shell go env GOROOT 2>/dev/null)
-goroot               := $(firstword $(GOROOT) $(goroot_github_env) $(goroot_github_cache) $(goroot_path))
+goroot               := $(firstword $(GOROOT) $(github_goroot_val) $(github_goroot_cache) $(goroot_path))
+
+ifndef goroot
+$(error could not determine GOROOT)
+endif
 
 # Ensure POSIX-style GOROOT even in Windows, to support PATH updates in bash.
 ifdef COMSPEC

--- a/Tools.mk
+++ b/Tools.mk
@@ -1,0 +1,7 @@
+# Copyright 2021 Tetrate
+# Licensed under the Apache License, Version 2.0 (the "License")
+
+golangci_lint := github.com/golangci/golangci-lint/cmd/golangci-lint@v1.42.1
+goimports     := golang.org/x/tools/cmd/goimports@v0.1.7
+hugo          := github.com/gohugoio/hugo@v0.88.1
+licenser      := github.com/liamawhite/licenser@v0.6.0


### PR DESCRIPTION
This switches from external (GitHub Actions workflow) to internal
(Makefile) for configuring GOROOT. Doing so reduces the amount of
copy/paste.

This also drops build cache, and moves tools to `Tools.mk` to
make the go cache config simpler and more precise.

A future change will remove configure_go.sh entirely, by rewriting how
internal images are produced.