### PR TITLE
Cleans up version selection logic

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -199,6 +199,11 @@ build/format: go.mod $(all_sources)
 	@$(go) mod tidy
 	@$(go) run $(licenser) apply -r "Tetrate"
 	@$(go)fmt -s -w $(all_sources)
+	@# Workaround inconsistent goimports grouping with awk until golang/go#20818 or incu6us/goimports-reviser#50
+	@for f in $(all_sources); do \
+	    awk '/^import \($$/,/^\)$$/{if($$0=="")next}{print}' $$f > /tmp/fmt; \
+	    mv /tmp/fmt $$f; \
+	done
 	@# -local ensures consistent ordering of our module in imports
 	@$(go) run $(goimports) -local $$(sed -ne 's/^module //gp' go.mod) -w $(all_sources)
 	@mkdir -p $(@D) && touch $@

--- a/e2e/func-e_versions_test.go
+++ b/e2e/func-e_versions_test.go
@@ -19,10 +19,9 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/tetratelabs/func-e/internal/moreos"
-
 	"github.com/stretchr/testify/require"
 
+	"github.com/tetratelabs/func-e/internal/moreos"
 	"github.com/tetratelabs/func-e/internal/version"
 )
 

--- a/internal/cmd/help_test.go
+++ b/internal/cmd/help_test.go
@@ -22,12 +22,11 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/tetratelabs/func-e/internal/version"
-
 	"github.com/stretchr/testify/require"
 
 	"github.com/tetratelabs/func-e/internal/globals"
 	"github.com/tetratelabs/func-e/internal/moreos"
+	"github.com/tetratelabs/func-e/internal/version"
 )
 
 func TestFuncEHelp(t *testing.T) {

--- a/internal/cmd/run_cmd_test.go
+++ b/internal/cmd/run_cmd_test.go
@@ -190,5 +190,5 @@ func TestFuncERun_ErrsWhenVersionsServerDown(t *testing.T) {
 	err := c.Run([]string{"func-e", "run"})
 
 	require.Contains(t, o.Out.(*bytes.Buffer).String(), moreos.Sprintf("looking up the latest Envoy version"))
-	require.Contains(t, err.Error(), fmt.Sprintf(`couldn't read latest version from %s`, o.EnvoyVersionsURL))
+	require.Contains(t, err.Error(), fmt.Sprintf(`couldn't lookup the latest Envoy version from %s`, o.EnvoyVersionsURL))
 }

--- a/internal/cmd/run_test.go
+++ b/internal/cmd/run_test.go
@@ -23,14 +23,11 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/stretchr/testify/require"
 	"github.com/urfave/cli/v2"
 
-	"github.com/tetratelabs/func-e/internal/moreos"
-
-	"github.com/stretchr/testify/require"
-
 	"github.com/tetratelabs/func-e/internal/globals"
-
+	"github.com/tetratelabs/func-e/internal/moreos"
 	"github.com/tetratelabs/func-e/internal/version"
 )
 

--- a/internal/cmd/run_test.go
+++ b/internal/cmd/run_test.go
@@ -15,11 +15,17 @@
 package cmd
 
 import (
+	"bytes"
 	"context"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/urfave/cli/v2"
+
+	"github.com/tetratelabs/func-e/internal/moreos"
 
 	"github.com/stretchr/testify/require"
 
@@ -28,39 +34,161 @@ import (
 	"github.com/tetratelabs/func-e/internal/version"
 )
 
+func TestEnsureEnvoyVersion(t *testing.T) {
+	o := &globals.GlobalOpts{HomeDir: t.TempDir()}
+	require.NoError(t, os.WriteFile(filepath.Join(o.HomeDir, "version"), []byte(version.LastKnownEnvoy.String()), 0600))
+
+	err := ensureEnvoyVersion(&cli.Context{Context: context.Background()}, o)
+	require.NoError(t, err)
+	require.Equal(t, version.LastKnownEnvoy, o.EnvoyVersion)
+}
+
+func TestEnsureEnvoyVersion_ErrorIsAValidationError(t *testing.T) {
+	o := &globals.GlobalOpts{HomeDir: t.TempDir()}
+	require.NoError(t, os.WriteFile(filepath.Join(o.HomeDir, "version"), []byte("a.b.c"), 0600))
+
+	expectedErr := fmt.Sprintf(`invalid version in "$FUNC_E_HOME/version": "a.b.c" should look like %q or %q`, version.LastKnownEnvoy, version.LastKnownEnvoyMinor)
+	err := ensureEnvoyVersion(&cli.Context{Context: context.Background()}, o)
+	require.IsType(t, err, &ValidationError{})
+	require.EqualError(t, err, moreos.ReplacePathSeparator(expectedErr))
+}
+
+func TestSetEnvoyVersion_ReadsExistingPatchVersion(t *testing.T) {
+	o := &globals.GlobalOpts{HomeDir: t.TempDir()}
+
+	require.NoError(t, os.WriteFile(filepath.Join(o.HomeDir, "version"), []byte("1.18.13"), 0600))
+
+	err := setEnvoyVersion(context.Background(), o)
+	require.NoError(t, err)
+	require.Equal(t, version.PatchVersion("1.18.13"), o.EnvoyVersion)
+}
+
+func TestSetEnvoyVersion_LooksUpLatestPatchForExistingMinorVersion(t *testing.T) {
+	o := &globals.GlobalOpts{
+		GetEnvoyVersions: func(context.Context) (*version.ReleaseVersions, error) {
+			return &version.ReleaseVersions{Versions: map[version.PatchVersion]version.Release{
+				"1.18.12": {Tarballs: map[version.Platform]version.TarballURL{globals.DefaultPlatform: ""}},
+				"1.18.13": {Tarballs: map[version.Platform]version.TarballURL{globals.DefaultPlatform: ""}},
+			}}, nil
+		},
+		HomeDir:  t.TempDir(),
+		Out:      new(bytes.Buffer), // we expect logging
+		Platform: globals.DefaultPlatform,
+	}
+
+	require.NoError(t, os.WriteFile(filepath.Join(o.HomeDir, "version"), []byte("1.18"), 0600))
+
+	err := setEnvoyVersion(context.Background(), o)
+	require.NoError(t, err)
+	require.Equal(t, version.PatchVersion("1.18.13"), o.EnvoyVersion)
+
+	// We notified the user about the remote lookup
+	require.Contains(t, o.Out.(*bytes.Buffer).String(), moreos.Sprintf("looking up the latest patch for Envoy version 1.18\n"))
+}
+
+func TestSetEnvoyVersion_ErrorReadingExistingVersion(t *testing.T) {
+	o := &globals.GlobalOpts{HomeDir: t.TempDir()}
+	require.NoError(t, os.WriteFile(filepath.Join(o.HomeDir, "version"), []byte("a.b.c"), 0600))
+
+	expectedErr := fmt.Sprintf(`invalid version in "$FUNC_E_HOME/version": "a.b.c" should look like %q or %q`, version.LastKnownEnvoy, version.LastKnownEnvoyMinor)
+	err := setEnvoyVersion(context.Background(), o)
+	require.EqualError(t, err, moreos.ReplacePathSeparator(expectedErr))
+}
+
+// TODO: this is not platform-specific see #393
+func TestSetEnvoyVersion_UsesLatestVersionOnInitialRun(t *testing.T) {
+	o := &globals.GlobalOpts{
+		GetEnvoyVersions: func(context.Context) (*version.ReleaseVersions, error) {
+			return &version.ReleaseVersions{LatestVersion: "1.18.13"}, nil
+		},
+		HomeDir: t.TempDir(),
+		Out:     new(bytes.Buffer), // we expect logging
+	}
+
+	err := setEnvoyVersion(context.Background(), o)
+	require.NoError(t, err)
+
+	// The LatestVersion was set
+	require.Equal(t, version.PatchVersion("1.18.13"), o.EnvoyVersion)
+
+	// We notified the user about the remote lookup
+	require.Contains(t, o.Out.(*bytes.Buffer).String(), moreos.Sprintf("looking up the latest Envoy version\n"))
+
+	// We persisted the minor component for next run!
+	writtenVersion, err := os.ReadFile(filepath.Join(o.HomeDir, "version"))
+	require.NoError(t, err)
+	require.Equal(t, o.EnvoyVersion.ToMinor().String(), string(writtenVersion))
+}
+
+func TestSetEnvoyVersion_ErrorLookingUpLatestVersionOnInitialRun(t *testing.T) {
+	o := &globals.GlobalOpts{
+		GetEnvoyVersions: func(context.Context) (*version.ReleaseVersions, error) {
+			return nil, errors.New("file not found")
+		},
+		EnvoyVersionsURL: "fake URL", // for logging
+		HomeDir:          t.TempDir(),
+		Out:              new(bytes.Buffer), // we expect logging
+	}
+
+	err := setEnvoyVersion(context.Background(), o)
+	require.EqualError(t, err, "couldn't lookup the latest Envoy version from fake URL: file not found")
+
+	// We notified the user about the remote lookup
+	require.Contains(t, o.Out.(*bytes.Buffer).String(), moreos.Sprintf("looking up the latest Envoy version\n"))
+
+	// No version file was written
+	require.NoFileExists(t, filepath.Join(o.HomeDir, "version"))
+}
+
 func TestEnsurePatchVersion(t *testing.T) {
 	versions := map[version.PatchVersion]version.Release{
-		version.PatchVersion("1.18.3"):       {},
-		version.PatchVersion("1.18.14"):      {},
-		version.PatchVersion("1.18.4"):       {},
-		version.PatchVersion("1.18.4_debug"): {},
+		version.PatchVersion("1.18.3"):       {Tarballs: map[version.Platform]version.TarballURL{globals.DefaultPlatform: ""}},
+		version.PatchVersion("1.18.13"):      {Tarballs: map[version.Platform]version.TarballURL{globals.DefaultPlatform: ""}},
+		version.PatchVersion("1.18.14"):      {Tarballs: map[version.Platform]version.TarballURL{"solaris/sparc64": ""}},
+		version.PatchVersion("1.18.4"):       {Tarballs: map[version.Platform]version.TarballURL{globals.DefaultPlatform: ""}},
+		version.PatchVersion("1.18.4_debug"): {Tarballs: map[version.Platform]version.TarballURL{globals.DefaultPlatform: ""}},
 	}
 
 	o := &globals.GlobalOpts{
 		GetEnvoyVersions: func(context.Context) (*version.ReleaseVersions, error) {
 			return &version.ReleaseVersions{Versions: versions}, nil
 		},
-		HomeDir: t.TempDir(),
+		HomeDir:  t.TempDir(),
+		Out:      new(bytes.Buffer), // we expect logging
+		Platform: globals.DefaultPlatform,
 	}
+
 	actual, err := ensurePatchVersion(context.Background(), o, version.MinorVersion("1.18"))
 	require.NoError(t, err)
-	require.Equal(t, version.PatchVersion("1.18.14"), actual)
+	require.Equal(t, version.PatchVersion("1.18.13"), actual)
+
+	// We notified the user about the remote lookup
+	require.Contains(t, o.Out.(*bytes.Buffer).String(), moreos.Sprintf("looking up the latest patch for Envoy version 1.18\n"))
 }
 
 func TestEnsurePatchVersion_NotFound(t *testing.T) {
 	versions := map[version.PatchVersion]version.Release{
-		version.PatchVersion("1.20.0"):    {},
-		version.PatchVersion("1.1_debug"): {},
+		version.PatchVersion("1.18.14"):   {Tarballs: map[version.Platform]version.TarballURL{"solaris/sparc64": ""}},
+		version.PatchVersion("1.20.0"):    {Tarballs: map[version.Platform]version.TarballURL{globals.DefaultPlatform: ""}},
+		version.PatchVersion("1.1_debug"): {Tarballs: map[version.Platform]version.TarballURL{globals.DefaultPlatform: ""}},
 	}
 
 	o := &globals.GlobalOpts{
 		GetEnvoyVersions: func(context.Context) (*version.ReleaseVersions, error) {
 			return &version.ReleaseVersions{Versions: versions}, nil
 		},
-		HomeDir: t.TempDir(),
+		EnvoyVersionsURL: "fake URL", // for logging
+		HomeDir:          t.TempDir(),
+		Out:              new(bytes.Buffer), // we expect logging
+		Platform:         globals.DefaultPlatform,
 	}
+
 	_, err := ensurePatchVersion(context.Background(), o, version.MinorVersion("1.18"))
-	require.EqualError(t, err, "couldn't find the latest patch for version 1.18")
+	expectedErr := fmt.Sprintf("fake URL does not contain an Envoy release for version 1.18 on platform %s", o.Platform)
+	require.EqualError(t, err, expectedErr)
+
+	// We notified the user about the remote lookup
+	require.Contains(t, o.Out.(*bytes.Buffer).String(), moreos.Sprintf("looking up the latest patch for Envoy version 1.18\n"))
 }
 
 func TestEnsurePatchVersion_NoOpWhenAlreadyAPatchVersion(t *testing.T) {
@@ -70,32 +198,71 @@ func TestEnsurePatchVersion_NoOpWhenAlreadyAPatchVersion(t *testing.T) {
 	require.Equal(t, expected, actual)
 }
 
-func TestEnsurePatchVersion_FallbackOnLookupFailure(t *testing.T) {
-	o := &globals.GlobalOpts{
-		GetEnvoyVersions: func(context.Context) (*version.ReleaseVersions, error) {
-			return nil, errors.New("ice cream")
+func TestEnsurePatchVersion_FallbackSuccess(t *testing.T) {
+	tests := []struct {
+		name             string
+		getEnvoyVersions version.GetReleaseVersions
+	}{
+		{
+			"error on lookup",
+			func(context.Context) (*version.ReleaseVersions, error) {
+				return nil, errors.New("file not found")
+			},
+		}, {
+			"no versions",
+			func(context.Context) (*version.ReleaseVersions, error) {
+				return &version.ReleaseVersions{}, nil
+			},
 		},
-		HomeDir: t.TempDir(),
+		{
+			"no versions for this platform",
+			func(context.Context) (*version.ReleaseVersions, error) {
+				return &version.ReleaseVersions{
+					Versions: map[version.PatchVersion]version.Release{
+						"1.18.14": {Tarballs: map[version.Platform]version.TarballURL{"solaris/sparc64": ""}},
+					},
+				}, nil
+			},
+		},
 	}
 
-	lastKnownEnvoyDir := filepath.Join(o.HomeDir, "versions", "1.18.14")
-	require.NoError(t, os.MkdirAll(lastKnownEnvoyDir, 0700))
+	for _, tc := range tests {
+		tc := tc // pin! see https://github.com/kyoh86/scopelint for why
+		t.Run(tc.name, func(t *testing.T) {
 
-	// Ensure that when we ask for a minor, the latest version is returned from the filesystem
-	actual, err := ensurePatchVersion(context.Background(), o, version.MinorVersion("1.18"))
-	require.NoError(t, err)
-	require.Equal(t, version.PatchVersion("1.18.14"), actual)
+			o := &globals.GlobalOpts{
+				GetEnvoyVersions: tc.getEnvoyVersions,
+				HomeDir:          t.TempDir(),
+				Out:              new(bytes.Buffer), // we expect logging
+			}
+
+			lastKnownEnvoyDir := filepath.Join(o.HomeDir, "versions", "1.18.14")
+			require.NoError(t, os.MkdirAll(lastKnownEnvoyDir, 0700))
+
+			// Ensure that when we ask for a minor, the latest version is returned from the filesystem
+			actual, err := ensurePatchVersion(context.Background(), o, version.MinorVersion("1.18"))
+			require.NoError(t, err)
+			require.Equal(t, version.PatchVersion("1.18.14"), actual)
+
+			// We notified the user about the remote lookup
+			require.Contains(t, o.Out.(*bytes.Buffer).String(), moreos.Sprintf("looking up the latest patch for Envoy version 1.18\n"))
+		})
+	}
 }
 
-func TestEnsurePatchVersion_RaisesErrorWhenNothingInstalled(t *testing.T) {
+func TestEnsurePatchVersion_FallbackFailure(t *testing.T) {
 	o := &globals.GlobalOpts{
 		GetEnvoyVersions: func(context.Context) (*version.ReleaseVersions, error) {
-			return nil, errors.New("ice cream")
+			return nil, errors.New("file not found")
 		},
 		HomeDir: t.TempDir(),
+		Out:     new(bytes.Buffer), // we expect logging
 	}
 
 	// Since we have nothing local to fall back to, we should raise the remote error
-	_, err := ensurePatchVersion(context.Background(), o, version.LastKnownEnvoyMinor)
-	require.EqualError(t, err, "ice cream")
+	_, err := ensurePatchVersion(context.Background(), o, version.MinorVersion("1.18"))
+	require.EqualError(t, err, "file not found")
+
+	// We notified the user about the remote lookup
+	require.Contains(t, o.Out.(*bytes.Buffer).String(), moreos.Sprintf("looking up the latest patch for Envoy version 1.18\n"))
 }

--- a/internal/cmd/versions.go
+++ b/internal/cmd/versions.go
@@ -47,8 +47,10 @@ func NewVersionsCmd(o *globals.GlobalOpts) *cli.Command {
 				return err
 			}
 
-			// tolerate errors determining current version, as that can be due to initial or out-of-band setup
-			currentVersion, currentVersionSource, _ := envoy.CurrentVersion(o.HomeDir)
+			currentVersion, currentVersionSource, err := envoy.CurrentVersion(o.HomeDir)
+			if err != nil {
+				return err
+			}
 
 			if c.Bool("all") {
 				if evs, err := o.GetEnvoyVersions(c.Context); err != nil {

--- a/internal/envoy/runtime.go
+++ b/internal/envoy/runtime.go
@@ -25,9 +25,8 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/tetratelabs/func-e/internal/moreos"
-
 	"github.com/tetratelabs/func-e/internal/globals"
+	"github.com/tetratelabs/func-e/internal/moreos"
 )
 
 const (

--- a/internal/envoy/version.go
+++ b/internal/envoy/version.go
@@ -32,21 +32,13 @@ const (
 	CurrentVersionHomeDirFile = "$FUNC_E_HOME/version"
 )
 
-// GetHomeVersion returns the default version in the "homeDir" and path to to it (homeVersionFile). When "v" is empty,
-// homeVersionFile is not yet initialized.
-func GetHomeVersion(homeDir string) (v version.Version, homeVersionFile string, err error) {
-	s, homeVersionFile, err := getHomeVersion(homeDir)
-	if err == nil && s == "" { // no home version, yet
-		return
-	}
-	v, err = verifyVersion(s, CurrentVersionHomeDirFile, err)
-	return
-}
-
 // WriteCurrentVersion writes the version to CurrentVersionWorkingDirFile or CurrentVersionHomeDirFile depending on
 // if the former is present.
 func WriteCurrentVersion(v version.Version, homeDir string) error {
 	if _, err := os.Stat(".envoy-version"); os.IsNotExist(err) {
+		if e := os.MkdirAll(homeDir, 0750); e != nil {
+			return e
+		}
 		return os.WriteFile(filepath.Join(homeDir, "version"), []byte(v.String()), 0600)
 	} else if err != nil {
 		return err
@@ -56,6 +48,7 @@ func WriteCurrentVersion(v version.Version, homeDir string) error {
 
 // CurrentVersion returns the first version in priority of VersionUsageList and its source or an error. The "source"
 // and error messages returned include unexpanded variables to clarify the intended context.
+// In the case no version was found, the version returned will be nil, not an error.
 func CurrentVersion(homeDir string) (v version.Version, source string, err error) {
 	s, source, err := getCurrentVersion(homeDir)
 	v, err = verifyVersion(s, source, err)
@@ -65,6 +58,8 @@ func CurrentVersion(homeDir string) (v version.Version, source string, err error
 func verifyVersion(v, source string, err error) (version.Version, error) {
 	if err != nil {
 		return nil, moreos.Errorf(`couldn't read version from %s: %w`, source, err)
+	} else if v == "" && source == CurrentVersionHomeDirFile { // don't error on initial state
+		return nil, nil
 	}
 	return version.NewVersion(fmt.Sprintf("version in %q", source), v)
 }
@@ -89,14 +84,13 @@ func getCurrentVersion(homeDir string) (v, source string, err error) {
 
 	// Priority 3: $FUNC_E_HOME/version
 	source = CurrentVersionHomeDirFile
-	v, _, err = getHomeVersion(homeDir)
+	v, err = getHomeVersion(homeDir)
 	return
 }
 
-func getHomeVersion(homeDir string) (v, homeVersionFile string, err error) {
-	homeVersionFile = filepath.Join(homeDir, "version")
+func getHomeVersion(homeDir string) (v string, err error) {
 	var data []byte
-	if data, err = os.ReadFile(homeVersionFile); err == nil {
+	if data, err = os.ReadFile(filepath.Join(homeDir, "version")); err == nil {
 		v = strings.TrimSpace(string(data))
 	} else if os.IsNotExist(err) {
 		err = nil // ok on file-not-found

--- a/internal/envoy/versions.go
+++ b/internal/envoy/versions.go
@@ -25,6 +25,7 @@ import (
 )
 
 // NewGetVersions creates a new Envoy versions fetcher.
+// TODO: validate the data before returning it!
 func NewGetVersions(envoyVersionsURL string, p version.Platform, v string) version.GetReleaseVersions {
 	return func(ctx context.Context) (*version.ReleaseVersions, error) {
 		// #nosec => This is by design, users can call out to wherever they like!

--- a/internal/envoy/versions_test.go
+++ b/internal/envoy/versions_test.go
@@ -18,11 +18,10 @@ import (
 	"context"
 	"testing"
 
-	"github.com/tetratelabs/func-e/internal/globals"
-	"github.com/tetratelabs/func-e/internal/test"
-
 	"github.com/stretchr/testify/require"
 
+	"github.com/tetratelabs/func-e/internal/globals"
+	"github.com/tetratelabs/func-e/internal/test"
 	"github.com/tetratelabs/func-e/internal/version"
 )
 


### PR DESCRIPTION
This removes an api for acknowledgement of the initial state. Doing so
also reduces file IO when environment variables select the version, as
in this case no default version file will be created.

This also fixes a bug where we had a false-positive on version selection.
Versions are platform-specific so we need to only be ok when the
current platform's tarball is available.

Next, this alerts the user when a remote lookup is happening. This was
missed before as we didn't let users know we are remotely resolving the
latest version.

Finally, this ensures there's enough information in warnings and errors
to troubleshoot a missing release. Particularly, there are cases where a
version is available, but not across the board. For example, linux exists,
but darwin does not.