### PR TITLE
Use t.Cleanup function to clean stuff after tests

### DIFF
--- a/e2e/func-e_run_test.go
+++ b/e2e/func-e_run_test.go
@@ -144,7 +144,7 @@ func envoyRunTest(t *testing.T, test func(context.Context, *funcE, *adminClient)
 
 	t.Cleanup(func() {
 		// this may not be present if the process was kill -9'd so don't error
-		require.NoError(t, os.Remove(c.runDir+".tar.gz"))
+		_ = os.Remove(c.runDir + ".tar.gz")
 	})
 
 	return c

--- a/internal/cmd/app_test.go
+++ b/internal/cmd/app_test.go
@@ -238,7 +238,7 @@ func runTestCommand(t *testing.T, o *globals.GlobalOpts, args []string) error {
 
 // setupTest returns globals.GlobalOpts and a tear-down function.
 // The tear-down functions reverts side-effects such as temp directories and a fake Envoy versions server.
-func setupTest(t *testing.T) (*globals.GlobalOpts, func()) {
+func setupTest(t *testing.T) *globals.GlobalOpts {
 	result := globals.GlobalOpts{}
 	result.EnvoyVersion = version.LastKnownEnvoy
 	result.Out = io.Discard // ignore logging by default
@@ -256,9 +256,10 @@ func setupTest(t *testing.T) (*globals.GlobalOpts, func()) {
 
 	result.GetEnvoyVersions = envoy.NewGetVersions(result.EnvoyVersionsURL, result.Platform, result.Version)
 
-	return &result, func() {
+	t.Cleanup(func() {
 		for i := len(tearDown) - 1; i >= 0; i-- {
 			tearDown[i]()
 		}
-	}
+	})
+	return &result
 }

--- a/internal/cmd/app_test.go
+++ b/internal/cmd/app_test.go
@@ -242,7 +242,6 @@ func setupTest(t *testing.T) *globals.GlobalOpts {
 	result := globals.GlobalOpts{}
 	result.EnvoyVersion = version.LastKnownEnvoy
 	result.Out = io.Discard // ignore logging by default
-	var tearDown []func()
 
 	tempDir := t.TempDir()
 
@@ -252,14 +251,8 @@ func setupTest(t *testing.T) *globals.GlobalOpts {
 
 	versionsServer := test.RequireEnvoyVersionsTestServer(t, version.LastKnownEnvoy)
 	result.EnvoyVersionsURL = versionsServer.URL + "/envoy-versions.json"
-	tearDown = append(tearDown, versionsServer.Close)
-
 	result.GetEnvoyVersions = envoy.NewGetVersions(result.EnvoyVersionsURL, result.Platform, result.Version)
 
-	t.Cleanup(func() {
-		for i := len(tearDown) - 1; i >= 0; i-- {
-			tearDown[i]()
-		}
-	})
+	t.Cleanup(versionsServer.Close)
 	return &result
 }

--- a/internal/cmd/run_cmd_test.go
+++ b/internal/cmd/run_cmd_test.go
@@ -50,8 +50,7 @@ func (r *runner) String() string {
 
 // TestFuncERun executes envoy then cancels the context. This results in no stdout
 func TestFuncERun(t *testing.T) {
-	o, cleanup := setupTest(t)
-	defer cleanup()
+	o := setupTest(t)
 
 	stdout := new(bytes.Buffer)
 	stderr := new(bytes.Buffer)
@@ -77,8 +76,7 @@ func TestFuncERun(t *testing.T) {
 }
 
 func TestFuncERun_TeesConsoleToLogs(t *testing.T) {
-	o, cleanup := setupTest(t)
-	defer cleanup()
+	o := setupTest(t)
 
 	c, stdout, stderr := newApp(o)
 	o.Out = io.Discard         // stdout/stderr only includes what envoy writes, not our status messages
@@ -97,10 +95,9 @@ func TestFuncERun_TeesConsoleToLogs(t *testing.T) {
 }
 
 func TestFuncERun_ReadsHomeVersionFile(t *testing.T) {
-	o, cleanup := setupTest(t)
+	o := setupTest(t)
 	o.EnvoyVersion = "" // pretend this is an initial setup
 	o.Out = new(bytes.Buffer)
-	defer cleanup()
 
 	require.NoError(t, os.WriteFile(filepath.Join(o.HomeDir, "version"), []byte(version.LastKnownEnvoyMinor), 0600))
 
@@ -117,10 +114,9 @@ func TestFuncERun_ReadsHomeVersionFile(t *testing.T) {
 }
 
 func TestFuncERun_CreatesHomeVersionFile(t *testing.T) {
-	o, cleanup := setupTest(t)
+	o := setupTest(t)
 	o.EnvoyVersion = "" // pretend this is an initial setup
 	o.Out = new(bytes.Buffer)
-	defer cleanup()
 
 	// make sure first run where the home doesn't exist yet, works!
 	require.NoError(t, os.RemoveAll(o.HomeDir))
@@ -144,9 +140,8 @@ func runWithoutConfig(t *testing.T, c *cli.App) {
 }
 
 func TestFuncERun_ValidatesHomeVersion(t *testing.T) {
-	o, cleanup := setupTest(t)
+	o := setupTest(t)
 	o.Out = new(bytes.Buffer)
-	defer cleanup()
 
 	o.EnvoyVersion = ""
 	require.NoError(t, os.WriteFile(filepath.Join(o.HomeDir, "version"), []byte("a.a.a"), 0600))
@@ -161,10 +156,9 @@ func TestFuncERun_ValidatesHomeVersion(t *testing.T) {
 
 // TestFuncERun_ValidatesWorkingVersion duplicates logic in version_test.go to ensure a non-home version validates.
 func TestFuncERun_ValidatesWorkingVersion(t *testing.T) {
-	o, cleanup := setupTest(t)
+	o := setupTest(t)
 	o.Out = new(bytes.Buffer)
 	o.EnvoyVersion = ""
-	defer cleanup()
 
 	revertWd := morerequire.RequireChdir(t, t.TempDir())
 	defer revertWd()

--- a/internal/cmd/use_test.go
+++ b/internal/cmd/use_test.go
@@ -31,8 +31,7 @@ import (
 )
 
 func TestFuncEUse_VersionValidates(t *testing.T) {
-	o, cleanup := setupTest(t)
-	defer cleanup()
+	o := setupTest(t)
 
 	tests := []struct{ name, version, expectedErr string }{
 		{
@@ -63,9 +62,8 @@ func TestFuncEUse_VersionValidates(t *testing.T) {
 }
 
 func TestFuncEUse_InstallsAndWritesHomeVersion(t *testing.T) {
-	o, cleanup := setupTest(t)
+	o := setupTest(t)
 	evs := o.EnvoyVersion.String()
-	defer cleanup()
 
 	c, _, _ := newApp(o)
 	require.NoError(t, c.Run([]string{"func-e", "use", evs}))
@@ -81,8 +79,7 @@ func TestFuncEUse_InstallsAndWritesHomeVersion(t *testing.T) {
 
 // TODO: everything from here down in this file needs to be rewritten
 func TestFuncEUse_InstallMinorVersion(t *testing.T) {
-	o, cleanup := setupTest(t)
-	defer cleanup()
+	o := setupTest(t)
 
 	type testCase struct {
 		name           string
@@ -160,8 +157,7 @@ func TestFuncEUse_InstallMinorVersion(t *testing.T) {
 }
 
 func TestFuncEUse_InstallMinorVersionCheckLatestPatchFailed(t *testing.T) {
-	o, cleanup := setupTest(t)
-	defer cleanup()
+	o := setupTest(t)
 
 	// The initial version to be installed.
 	minorVersion := "1.12"

--- a/internal/cmd/versions_cmd_test.go
+++ b/internal/cmd/versions_cmd_test.go
@@ -29,8 +29,7 @@ import (
 )
 
 func TestFuncEVersions_NothingYet(t *testing.T) {
-	o, cleanup := setupTest(t)
-	defer cleanup()
+	o := setupTest(t)
 
 	c, stdout, stderr := newApp(o)
 	err := c.Run([]string{"func-e", "versions"})
@@ -41,8 +40,7 @@ func TestFuncEVersions_NothingYet(t *testing.T) {
 }
 
 func TestFuncEVersions_NoCurrentVersion(t *testing.T) {
-	o, cleanup := setupTestVersions(t)
-	defer cleanup()
+	o := setupTestVersions(t)
 	require.NoError(t, os.Remove(filepath.Join(o.HomeDir, "version")))
 
 	c, stdout, stderr := newApp(o)
@@ -59,8 +57,7 @@ func TestFuncEVersions_NoCurrentVersion(t *testing.T) {
 // TestFuncEVersions_CurrentVersion tests depend on prior state, so execute sequentially. This doesn't use a matrix
 // to improve readability
 func TestFuncEVersions_CurrentVersion(t *testing.T) {
-	o, cleanup := setupTestVersions(t)
-	defer cleanup()
+	o := setupTestVersions(t)
 
 	t.Run("no current version", func(t *testing.T) {
 		require.NoError(t, os.Remove(filepath.Join(o.HomeDir, "version")))
@@ -110,8 +107,7 @@ func TestFuncEVersions_CurrentVersion(t *testing.T) {
 }
 
 func TestFuncEVersions_Sorted(t *testing.T) {
-	o, cleanup := setupTestVersions(t)
-	defer cleanup()
+	o := setupTestVersions(t)
 
 	c, stdout, stderr := newApp(o)
 	err := c.Run([]string{"func-e", "versions"})
@@ -125,8 +121,7 @@ func TestFuncEVersions_Sorted(t *testing.T) {
 }
 
 func TestFuncEVersions_All_OnlyRemote(t *testing.T) {
-	o, cleanup := setupTest(t)
-	defer cleanup()
+	o := setupTest(t)
 
 	c, stdout, stderr := newApp(o)
 	err := c.Run([]string{"func-e", "versions", "-a"})
@@ -137,8 +132,7 @@ func TestFuncEVersions_All_OnlyRemote(t *testing.T) {
 }
 
 func TestFuncEVersions_All_RemoteIsCurrent(t *testing.T) {
-	o, cleanup := setupTest(t)
-	defer cleanup()
+	o := setupTest(t)
 
 	v := version.LastKnownEnvoy.String()
 	versionDir := filepath.Join(o.HomeDir, "versions", v)
@@ -157,8 +151,7 @@ func TestFuncEVersions_All_RemoteIsCurrent(t *testing.T) {
 }
 
 func TestFuncEVersions_All_Mixed(t *testing.T) {
-	o, cleanup := setupTestVersions(t)
-	defer cleanup()
+	o := setupTestVersions(t)
 
 	c, stdout, stderr := newApp(o)
 	err := c.Run([]string{"func-e", "versions", "-a"})
@@ -172,8 +165,8 @@ func TestFuncEVersions_All_Mixed(t *testing.T) {
 	require.Empty(t, stderr)
 }
 
-func setupTestVersions(t *testing.T) (o *globals.GlobalOpts, cleanup func()) {
-	o, cleanup = setupTest(t)
+func setupTestVersions(t *testing.T) (o *globals.GlobalOpts) {
+	o = setupTest(t)
 
 	oneOneTwo := filepath.Join(o.HomeDir, "versions", "1.1.2")
 	require.NoError(t, os.MkdirAll(oneOneTwo, 0700))

--- a/internal/cmd/which_test.go
+++ b/internal/cmd/which_test.go
@@ -29,8 +29,7 @@ func (r *runner) Which(ctx context.Context, args []string) error {
 }
 
 func TestFuncEWhich(t *testing.T) {
-	o, cleanup := setupTest(t)
-	defer cleanup()
+	o := setupTest(t)
 
 	c, stdout, stderr := newApp(o)
 

--- a/internal/envoy/install_test.go
+++ b/internal/envoy/install_test.go
@@ -262,8 +262,6 @@ func setupInstallTest(t *testing.T) *installTest {
 		},
 	}
 	setup.GetEnvoyVersions = NewGetVersions(setup.EnvoyVersionsURL, setup.Platform, setup.Version)
-	t.Cleanup(func() {
-		versionsServer.Close()
-	})
+	t.Cleanup(versionsServer.Close)
 	return setup
 }

--- a/internal/envoy/install_test.go
+++ b/internal/envoy/install_test.go
@@ -103,8 +103,7 @@ func TestUntarEnvoy(t *testing.T) {
 }
 
 func TestInstallIfNeeded_ErrorOnIncorrectURL(t *testing.T) {
-	o, cleanup := setupInstallTest(t)
-	defer cleanup()
+	o := setupInstallTest(t)
 
 	o.EnvoyVersionsURL += "/varsionz.json"
 	o.GetEnvoyVersions = NewGetVersions(o.EnvoyVersionsURL, o.Platform, o.Version)
@@ -115,8 +114,7 @@ func TestInstallIfNeeded_ErrorOnIncorrectURL(t *testing.T) {
 }
 
 func TestInstallIfNeeded_Validates(t *testing.T) {
-	o, cleanup := setupInstallTest(t)
-	defer cleanup()
+	o := setupInstallTest(t)
 
 	tests := []struct {
 		name        string
@@ -152,8 +150,7 @@ func TestInstallIfNeeded_Validates(t *testing.T) {
 }
 
 func TestInstallIfNeeded(t *testing.T) {
-	o, cleanup := setupInstallTest(t)
-	defer cleanup()
+	o := setupInstallTest(t)
 	out := o.Out.(*bytes.Buffer)
 
 	o.EnvoyVersion = version.LastKnownEnvoy
@@ -172,8 +169,7 @@ func TestInstallIfNeeded(t *testing.T) {
 }
 
 func TestInstallIfNeeded_NotFound(t *testing.T) {
-	o, cleanup := setupInstallTest(t)
-	defer cleanup()
+	o := setupInstallTest(t)
 
 	t.Run("unknown version", func(t *testing.T) {
 		o.Platform = "darwin/amd64"
@@ -190,8 +186,7 @@ func TestInstallIfNeeded_NotFound(t *testing.T) {
 }
 
 func TestInstallIfNeeded_AlreadyExists(t *testing.T) {
-	o, cleanup := setupInstallTest(t)
-	defer cleanup()
+	o := setupInstallTest(t)
 	out := o.Out.(*bytes.Buffer)
 
 	require.NoError(t, os.MkdirAll(filepath.Dir(o.EnvoyPath), 0700))
@@ -249,7 +244,7 @@ type installTest struct {
 	tarballURL version.TarballURL
 }
 
-func setupInstallTest(t *testing.T) (*installTest, func()) {
+func setupInstallTest(t *testing.T) *installTest {
 	versionsServer := test.RequireEnvoyVersionsTestServer(t, version.LastKnownEnvoy)
 	homeDir := t.TempDir()
 	setup := &installTest{
@@ -267,5 +262,8 @@ func setupInstallTest(t *testing.T) (*installTest, func()) {
 		},
 	}
 	setup.GetEnvoyVersions = NewGetVersions(setup.EnvoyVersionsURL, setup.Platform, setup.Version)
-	return setup, versionsServer.Close
+	t.Cleanup(func() {
+		versionsServer.Close()
+	})
+	return setup
 }


### PR DESCRIPTION
Reference: https://golang.org/doc/go1.14#testing

Since the `t *testing.T` is being passed through many functions, we should use t.Cleanup(func() { }) to clean stuff instead of letting each individual test cases do this.