### PR TITLE
Uses latest runners when running tests

### DIFF
--- a/.github/workflows/commit.yaml
+++ b/.github/workflows/commit.yaml
@@ -44,7 +44,7 @@ jobs:
     timeout-minutes: 90  # instead of 360 by default
     strategy:
       fail-fast: false  # don't fail fast as sometimes failures are operating system specific
-      matrix:
+      matrix:  # use latest available versions and be consistent on all workflows!
         os: [ubuntu-20.04, macos-11, windows-2022]
 
     steps:

--- a/.github/workflows/commit.yaml
+++ b/.github/workflows/commit.yaml
@@ -45,7 +45,7 @@ jobs:
     strategy:
       fail-fast: false  # don't fail fast as sometimes failures are operating system specific
       matrix:
-        os: [ubuntu-20.04, macos-latest, windows-latest]
+        os: [ubuntu-20.04, macos-11, windows-2022]
 
     steps:
       - name: "Checkout"

--- a/.github/workflows/packaging.yaml
+++ b/.github/workflows/packaging.yaml
@@ -46,10 +46,10 @@ jobs:
           - os: ubuntu-20.04  # Hard-coding an LTS means maintenance, but only once each 2 years!
             setup: sudo apt update -qq && sudo apt install -qq -y wixl msitools osslsigncode
           # macos is missing wixl https://github.com/actions/virtual-environments/issues/3857
-          - os: macos-latest
+          - os: macos-11
             setup: brew install -q msitools osslsigncode
           # wixtoolset isn't in the path https://github.com/wixtoolset/wix3/blob/develop/src/Setup/CoreMsi/Toolset.wxs#L87
-          - os: windows-latest
+          - os: windows-2022
             setup: |
               echo "$WIX\\bin" >> $GITHUB_PATH
               osslsigncode_version=2.2

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -41,8 +41,6 @@ jobs:
           WINDOWS_CODESIGN_P12: ${{ steps.p12.outputs.filePath }}
           WINDOWS_CODESIGN_PASSWORD: ${{ secrets.WINDOWS_CODESIGN_PASSWORD }}
 
-      # The release notable has a discussion channel to avoid people having to
-      # raise issues to ask about it.
       - name: "Create draft release"
         run: |
           tag="${GITHUB_REF#refs/tags/}"
@@ -63,9 +61,9 @@ jobs:
         include:
           - os: ubuntu-20.04  # Hard-coding an LTS means maintenance, but only once each 2 years!
             pattern: '*linux_amd64.tar.gz'
-          - os: macos-latest
+          - os: macos-11
             pattern: '*darwin_amd64.tar.gz'
-          - os: windows-latest
+          - os: windows-2022
             pattern: '*windows_amd64.*'
             unzip: | # the above downloads both the zip and msi, stash the msi name
               printf "::set-output name=msi::%s\n" *.msi


### PR DESCRIPTION
func-e is an introductory tool, so we can optimize to test the latest
available OS vs what GitHub Actions marks as latest (often years old).

Note: MacOS 12 is not supported on GHA, still!

https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners