### PR TITLE
Make the example on func-e.io pastable into a terminal

### DIFF
--- a/site/content/_index.md
+++ b/site/content/_index.md
@@ -9,10 +9,10 @@ your behalf. This makes knowledge sharing and troubleshooting easier, especially
 
 ```sh
 curl https://func-e.io/install.sh | bash -s -- -b /usr/local/bin
+func-e run -c /path/to/envoy.yaml
 ```
 
+If you don't have a configuration file, you can start the admin port like this:
 ```sh
-func-e run -c /path/to/envoy.yaml
-# If you don't have a configuration file, you can start the admin port like this
 func-e run --config-yaml "admin: {address: {socket_address: {address: '127.0.0.1', port_value: 9901}}}"
 ```

--- a/site/content/_index.md
+++ b/site/content/_index.md
@@ -8,8 +8,11 @@ configuration you would use in production. Each time you end a run, a snapshot o
 your behalf. This makes knowledge sharing and troubleshooting easier, especially when upgrading. Try it out!
 
 ```sh
-$ curl https://func-e.io/install.sh | bash -s -- -b /usr/local/bin
-$ func-e run -c /path/to/envoy.yaml
+curl https://func-e.io/install.sh | bash -s -- -b /usr/local/bin
+```
+
+```sh
+func-e run -c /path/to/envoy.yaml
 # If you don't have a configuration file, you can start the admin port like this
-$ func-e run --config-yaml "admin: {address: {socket_address: {address: '127.0.0.1', port_value: 9901}}}"
+func-e run --config-yaml "admin: {address: {socket_address: {address: '127.0.0.1', port_value: 9901}}}"
 ```


### PR DESCRIPTION
Currently it includes the leading $, and includes the whole block, this
change removes the leading $ and splits it into two blocks, one for the
install command, and the other to run func-e