### PR TITLE
fixes race condition in Run by decoupling singal handling from the impl

### DIFF
--- a/api/run.go
+++ b/api/run.go
@@ -61,6 +61,13 @@ func Out(out io.Writer) RunOption {
 	}
 }
 
+// ErrOut is where error messages are written. Defaults to os.Stderr
+func ErrOut(err io.Writer) RunOption {
+	return func(o *runOpts) {
+		o.errOut = err
+	}
+}
+
 // RunOption is configuration for Run.
 type RunOption func(*runOpts)
 
@@ -68,7 +75,7 @@ type runOpts struct {
 	homeDir          string
 	envoyVersion     string
 	envoyVersionsURL string
-	out              io.Writer
+	out, errOut      io.Writer
 }
 
 // Run downloads Envoy and runs it as a process with the arguments

--- a/api/run.go
+++ b/api/run.go
@@ -61,13 +61,6 @@ func Out(out io.Writer) RunOption {
 	}
 }
 
-// ErrOut is where error messages are written. Defaults to os.Stderr
-func ErrOut(err io.Writer) RunOption {
-	return func(o *runOpts) {
-		o.errOut = err
-	}
-}
-
 // RunOption is configuration for Run.
 type RunOption func(*runOpts)
 
@@ -75,7 +68,7 @@ type runOpts struct {
 	homeDir          string
 	envoyVersion     string
 	envoyVersionsURL string
-	out, errOut      io.Writer
+	out              io.Writer
 }
 
 // Run downloads Envoy and runs it as a process with the arguments

--- a/internal/cmd/run_cmd_test.go
+++ b/internal/cmd/run_cmd_test.go
@@ -22,6 +22,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 	"github.com/urfave/cli/v2"
@@ -60,7 +61,7 @@ func TestFuncERun(t *testing.T) {
 	// tee the error stream so we can look for the "starting main dispatch loop" line without consuming it.
 	errCopy := new(bytes.Buffer)
 	c.ErrWriter = io.MultiWriter(stderr, errCopy)
-	err := test.RequireRun(t, nil, &runner{c, stdout, stderr}, errCopy, args...)
+	err := test.RequireRun(t, 3*time.Second, &runner{c, stdout, stderr}, errCopy, args...)
 
 	require.NoError(t, err)
 	require.Empty(t, stdout)

--- a/internal/envoy/run.go
+++ b/internal/envoy/run.go
@@ -66,7 +66,7 @@ func (r *Runtime) Run(ctx context.Context, args []string) error {
 	case <-ctx.Done():
 		// When original context is done, we need to shutdown the process by ourselves.
 		// Run the shutdown hooks and wait for them to complete.
-		r.handleShutdown(ctx)
+		r.handleShutdown()
 		// Then wait for the process to exit.
 		<-cmdExitWait.Done()
 	case <-cmdExitWait.Done():

--- a/internal/envoy/run.go
+++ b/internal/envoy/run.go
@@ -28,7 +28,7 @@ import (
 
 // Run execs the binary at the path with the args passed. It is a blocking function that can be shutdown via ctx.
 //
-// This will exit either `ctx` is done, or the process exits. If the process exits, the exit code is checked. If the
+// This will exit either `ctx` is done, or the process exits.
 func (r *Runtime) Run(ctx context.Context, args []string) error {
 	// We can't use CommandContext even if that seems correct here. The reason is that we need to invoke shutdown hooks,
 	// and they expect the process to still be running. For example, this allows admin API hooks.

--- a/internal/envoy/run.go
+++ b/internal/envoy/run.go
@@ -52,6 +52,9 @@ func (r *Runtime) Run(ctx context.Context, args []string) error {
 	r.maybeWarn(os.WriteFile(r.pidPath, []byte(strconv.Itoa(cmd.Process.Pid)), 0o600))
 
 	// Wait in a goroutine. We may need to kill the process if a signal occurs first.
+	//
+	// Note: do not wrap the original context, otherwise "<-cmdExitWait.Done()" won't block until the process exits
+	// if the original context is done.
 	cmdExitWait, cmdExit := context.WithCancel(context.Background())
 	defer cmdExit()
 	go func() {

--- a/internal/envoy/run.go
+++ b/internal/envoy/run.go
@@ -19,16 +19,16 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
-	"os/signal"
 	"strconv"
 	"strings"
-	"syscall"
 	"time"
 
 	"github.com/tetratelabs/func-e/internal/moreos"
 )
 
-// Run execs the binary at the path with the args passed. It is a blocking function that can be shutdown via SIGINT.
+// Run execs the binary at the path with the args passed. It is a blocking function that can be shutdown via ctx.
+//
+// This will exit either `ctx` is done, or the process exits. If the process exits, the exit code is checked. If the
 func (r *Runtime) Run(ctx context.Context, args []string) error {
 	// We can't use CommandContext even if that seems correct here. The reason is that we need to invoke shutdown hooks,
 	// and they expect the process to still be running. For example, this allows admin API hooks.
@@ -51,37 +51,25 @@ func (r *Runtime) Run(ctx context.Context, args []string) error {
 	// Warn, but don't fail if we can't write the pid file for some reason
 	r.maybeWarn(os.WriteFile(r.pidPath, []byte(strconv.Itoa(cmd.Process.Pid)), 0o600))
 
-	waitCtx, waitCancel := context.WithCancel(ctx)
-	defer waitCancel()
-
-	sigCtx, sigCancel := signal.NotifyContext(waitCtx, syscall.SIGINT, syscall.SIGTERM)
-	defer sigCancel()
-	r.FakeInterrupt = sigCancel
-
 	// Wait in a goroutine. We may need to kill the process if a signal occurs first.
+	cmdExitWait, cmdExit := context.WithCancel(context.Background())
+	defer cmdExit()
 	go func() {
-		defer waitCancel()
-		_ = r.cmd.Wait() // Envoy logs like "caught SIGINT" or "caught ENVOY_SIGTERM", so we don't repeat logging here.
+		defer cmdExit()
+		_ = r.cmd.Wait()
 	}()
 
-	awaitAdminAddress(sigCtx, r)
+	awaitAdminAddress(ctx, r)
 
-	// Block until we receive SIGINT or are canceled because Envoy has died
-	<-sigCtx.Done()
-
-	// The process could have exited due to incorrect arguments or otherwise.
-	// If it is still running, run shutdown hooks and propagate the interrupt.
-	if cmd.ProcessState == nil {
-		r.handleShutdown(ctx)
-	}
-
-	// At this point, shutdown hooks have run and Envoy is interrupted.
-	// Block until it exits to ensure file descriptors are closed prior to archival.
-	// Allow up to 5 seconds for a clean stop, killing if it can't for any reason.
+	// Block until the process exits or the original context is done.
 	select {
-	case <-waitCtx.Done(): // cmd.Wait goroutine finished
-	case <-time.After(5 * time.Second):
-		_ = moreos.EnsureProcessDone(r.cmd.Process)
+	case <-ctx.Done():
+		// When original context is done, we need to shutdown the process by ourselves.
+		// Run the shutdown hooks and wait for them to complete.
+		r.handleShutdown(ctx)
+		// Then wait for the process to exit.
+		<-cmdExitWait.Done()
+	case <-cmdExitWait.Done():
 	}
 
 	// Warn, but don't fail on error archiving the run directory

--- a/internal/envoy/run_test.go
+++ b/internal/envoy/run_test.go
@@ -18,15 +18,14 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"github.com/shirou/gopsutil/v3/process"
+	"github.com/stretchr/testify/require"
 	"io"
 	"os"
 	"path/filepath"
 	"strconv"
 	"testing"
 	"time"
-
-	"github.com/shirou/gopsutil/v3/process"
-	"github.com/stretchr/testify/require"
 
 	"github.com/tetratelabs/func-e/internal/globals"
 	"github.com/tetratelabs/func-e/internal/moreos"
@@ -47,14 +46,16 @@ func TestRuntime_Run(t *testing.T) {
 	tests := []struct {
 		name                           string
 		args                           []string
-		shutdown                       func()
+		shutdown                       bool
+		timeout                        time.Duration
 		expectedStdout, expectedStderr string
 		expectedErr                    string
 		wantShutdownHook               bool
 	}{
 		{
-			name: "func-e Ctrl+C",
-			args: []string{"-c", "envoy.yaml"},
+			name:    "func-e Ctrl+C",
+			args:    []string{"-c", "envoy.yaml"},
+			timeout: time.Second,
 			// Don't warn the user when they exited the process
 			expectedStdout:   moreos.Sprintf("starting: %s -c envoy.yaml %s\n", fakeEnvoy, adminFlag),
 			expectedStderr:   moreos.Sprintf("initializing epoch 0\nstarting main dispatch loop\ncaught SIGINT\nexiting\n"),
@@ -64,7 +65,6 @@ func TestRuntime_Run(t *testing.T) {
 		// Envoy returns exit status zero on anything except kill -9. We can't test kill -9 with a fake shell script.
 		{
 			name:           "Envoy exited with error",
-			shutdown:       func() { time.Sleep(time.Millisecond * 100) },
 			args:           []string{}, // no config file!
 			expectedStdout: moreos.Sprintf("starting: %s %s\n", fakeEnvoy, adminFlag),
 			expectedStderr: moreos.Sprintf("initializing epoch 0\nexiting\nAt least one of --config-path or --config-yaml or Options::configProto() should be non-empty\n"),
@@ -102,15 +102,10 @@ func TestRuntime_Run(t *testing.T) {
 				return nil
 			})
 
-			shutdown := tc.shutdown
-			if shutdown == nil {
-				shutdown = ctrlC(r)
-			}
-
 			// tee the error stream so we can look for the "starting main dispatch loop" line without consuming it.
 			errCopy := new(bytes.Buffer)
 			r.Err = io.MultiWriter(r.Err, errCopy)
-			err := test.RequireRun(t, shutdown, r, errCopy, tc.args...)
+			err := test.RequireRun(t, tc.timeout, r, errCopy, tc.args...)
 
 			if tc.expectedErr == "" {
 				require.NoError(t, err)
@@ -128,8 +123,8 @@ func TestRuntime_Run(t *testing.T) {
 			require.Equal(t, tc.wantShutdownHook, haveShutdownHook)
 
 			// Validate we ran what we thought we did
-			require.Equal(t, tc.expectedStdout, stdout.String())
-			require.Equal(t, tc.expectedStderr, stderr.String())
+			require.Contains(t, stdout.String(), tc.expectedStdout)
+			require.Contains(t, stderr.String(), tc.expectedStderr)
 
 			// Ensure the working directory was deleted, and the "run" directory only contains the archive
 			files, err := os.ReadDir(runsDir)
@@ -141,15 +136,6 @@ func TestRuntime_Run(t *testing.T) {
 			// Cleanup for the next run
 			require.NoError(t, os.Remove(archive))
 		})
-	}
-}
-
-func ctrlC(r *Runtime) func() {
-	return func() {
-		fakeInterrupt := r.FakeInterrupt
-		if fakeInterrupt != nil {
-			fakeInterrupt()
-		}
 	}
 }
 

--- a/internal/envoy/run_test.go
+++ b/internal/envoy/run_test.go
@@ -18,14 +18,15 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"github.com/shirou/gopsutil/v3/process"
-	"github.com/stretchr/testify/require"
 	"io"
 	"os"
 	"path/filepath"
 	"strconv"
 	"testing"
 	"time"
+
+	"github.com/shirou/gopsutil/v3/process"
+	"github.com/stretchr/testify/require"
 
 	"github.com/tetratelabs/func-e/internal/globals"
 	"github.com/tetratelabs/func-e/internal/moreos"

--- a/internal/envoy/runtime.go
+++ b/internal/envoy/runtime.go
@@ -52,10 +52,6 @@ type Runtime struct {
 
 	adminAddress, adminAddressPath, pidPath string
 
-	// FakeInterrupt is exposed for unit tests to pretend "func-e run" received a Ctrl+C or Ctrl+Break.
-	// End-to-end tests should kill the func-e process to achieve the same.
-	FakeInterrupt context.CancelFunc
-
 	shutdownHooks []func(context.Context) error
 }
 

--- a/internal/envoy/shutdown.go
+++ b/internal/envoy/shutdown.go
@@ -36,7 +36,7 @@ func (r *Runtime) handleShutdown(ctx context.Context) {
 	defer r.interruptEnvoy() // Ensure the SIGINT forwards to Envoy even if a shutdown hook panics
 
 	deadline := time.Now().Add(shutdownTimeout)
-	timeout, cancel := context.WithDeadline(ctx, deadline)
+	timeout, cancel := context.WithDeadline(context.Background(), deadline)
 	defer cancel()
 
 	moreos.Fprintf(r.Out, "invoking shutdown hooks with deadline %s\n", deadline.Format(dateFormat))

--- a/internal/envoy/shutdown.go
+++ b/internal/envoy/shutdown.go
@@ -32,7 +32,7 @@ func (r *Runtime) RegisterShutdownHook(f func(context.Context) error) {
 	r.shutdownHooks = append(r.shutdownHooks, f)
 }
 
-func (r *Runtime) handleShutdown(ctx context.Context) {
+func (r *Runtime) handleShutdown() {
 	defer r.interruptEnvoy() // Ensure the SIGINT forwards to Envoy even if a shutdown hook panics
 
 	deadline := time.Now().Add(shutdownTimeout)

--- a/internal/envoy/shutdown/admin.go
+++ b/internal/envoy/shutdown/admin.go
@@ -21,6 +21,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"time"
 
 	"golang.org/x/sync/errgroup"
 
@@ -65,6 +66,8 @@ func (e *envoyAdminDataCollection) retrieveAdminAPIData(ctx context.Context) err
 		file := filepath.Join(e.workingDir, f)
 
 		g.Go(func() error {
+			ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+			defer cancel()
 			return copyURLToFile(ctx, url, file)
 		})
 	}

--- a/internal/envoy/shutdown/admin_test.go
+++ b/internal/envoy/shutdown/admin_test.go
@@ -20,6 +20,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
@@ -56,10 +57,5 @@ func runWithShutdownHook(t *testing.T, runDir string, hook func(r *envoy.Runtime
 	r.Err = stderr
 	require.NoError(t, hook(r))
 
-	return test.RequireRun(t, func() {
-		fakeInterrupt := r.FakeInterrupt
-		if fakeInterrupt != nil {
-			fakeInterrupt()
-		}
-	}, r, stderr, "-c", "envoy.yaml")
+	return test.RequireRun(t, 10*time.Second, r, stderr, "-c", "envoy.yaml")
 }


### PR DESCRIPTION
Redo of #456. Basically, the original impl had a race condition and cannot wait for the Envoy processes to actually exit plus there was a race condition when accessing exec.Process objects. This fixes it altogether by decoupling internal/envoy/run implementation from the actual signal handling and making it focus on the simple context cancelation.