### PR TITLE
Suppress noisy logging

### DIFF
--- a/internal/envoy/run.go
+++ b/internal/envoy/run.go
@@ -42,7 +42,7 @@ func (r *Runtime) Run(ctx context.Context, args []string) error {
 	}
 
 	// Print the binary path to the user for debugging purposes.
-	moreos.Fprintf(r.Out, "starting: %s\n", r.opts.EnvoyPath) //nolint
+	moreos.Fprintf(r.Out, "starting: %s with --admin-address-path %s\n", r.opts.EnvoyPath, r.adminAddressPath) //nolint
 	if err := cmd.Start(); err != nil {
 		return fmt.Errorf("unable to start Envoy process: %w", err)
 	}

--- a/internal/envoy/run.go
+++ b/internal/envoy/run.go
@@ -20,7 +20,6 @@ import (
 	"os"
 	"os/exec"
 	"strconv"
-	"strings"
 	"time"
 
 	"github.com/tetratelabs/func-e/internal/moreos"
@@ -42,8 +41,8 @@ func (r *Runtime) Run(ctx context.Context, args []string) error {
 		return err
 	}
 
-	// Print the process line to the console for user knowledge and parsing convenience
-	moreos.Fprintf(r.Out, "starting: %s\n", strings.Join(r.cmd.Args, " ")) //nolint
+	// Print the binary path to the user for debugging purposes.
+	moreos.Fprintf(r.Out, "starting: %s\n", r.opts.EnvoyPath) //nolint
 	if err := cmd.Start(); err != nil {
 		return fmt.Errorf("unable to start Envoy process: %w", err)
 	}

--- a/internal/envoy/run_test.go
+++ b/internal/envoy/run_test.go
@@ -120,7 +120,7 @@ func TestRuntime_Run(t *testing.T) {
 			require.Equal(t, tc.wantShutdownHook, haveShutdownHook)
 
 			// Validate we ran what we thought we did
-			require.Contains(t, stdout.String(), moreos.Sprintf("starting: %s\n", fakeEnvoy))
+			require.Contains(t, stdout.String(), moreos.Sprintf("starting: %s", fakeEnvoy))
 			require.Contains(t, stderr.String(), tc.expectedStderr)
 
 			// Ensure the working directory was deleted, and the "run" directory only contains the archive

--- a/internal/moreos/moreos_func-e_test.go
+++ b/internal/moreos/moreos_func-e_test.go
@@ -113,7 +113,7 @@ func Test_CallSignals(t *testing.T) {
 
 			// Block until we reach an expected line or timeout.
 			requireScannedWaitFor(t, stderrScanner, "starting main dispatch loop")
-			require.Equal(t, Sprintf("starting: %s\n", fakeEnvoy), stdout.String())
+			require.Equal(t, Sprintf("starting: %s %s -c\n", fakeEnvoy, arg), stdout.String())
 
 			fakeFuncEProcess, err := process.NewProcess(int32(cmd.Process.Pid))
 			require.NoError(t, err)

--- a/internal/moreos/moreos_func-e_test.go
+++ b/internal/moreos/moreos_func-e_test.go
@@ -113,7 +113,7 @@ func Test_CallSignals(t *testing.T) {
 
 			// Block until we reach an expected line or timeout.
 			requireScannedWaitFor(t, stderrScanner, "starting main dispatch loop")
-			require.Equal(t, Sprintf("starting: %s %s -c\n", fakeEnvoy, arg), stdout.String())
+			require.Equal(t, Sprintf("starting: %s\n", fakeEnvoy), stdout.String())
 
 			fakeFuncEProcess, err := process.NewProcess(int32(cmd.Process.Pid))
 			require.NoError(t, err)


### PR DESCRIPTION
func-e runs Envoy for given args, so there's no reason to log all arguments as that should be trivial to users. The only portion that is not trivial during debugging is the binary location managed by func-e, so this switches to print it only. This will suppress crazy large output by a library user such as Envoy Gateway that passes a giant literal yaml.