### PR TITLE
Don't spawn processes in separate group on darwin

### DIFF
--- a/internal/moreos/proc_attr_darwin.go
+++ b/internal/moreos/proc_attr_darwin.go
@@ -19,5 +19,8 @@ import (
 )
 
 func processGroupAttr() *syscall.SysProcAttr {
-	return &syscall.SysProcAttr{Setpgid: true}
+	// Don't spawn in separate process groups on darwin because there is no
+	// way to ensure they get killed when func-e gets killed and will leave
+	// zombies.
+	return nil
 }


### PR DESCRIPTION
Unlike linux, where we can set `Pdeathsig`, darwin does not have a way to spawn in a different process group and also ensure it is killed with the parent. This means killing func-e, or any user such as envoy gateway, will not kill envoy, leaving zombies. I am suspicious of spawning in a different process group being necessary in any situation, func-e feels like a typical use case for them - but on macos at least, CI passes with this change, and zombies are something that should never be allowed, so it seems better to me. Windows might have the same issue but didn't check it.

For reference, removing separate process group does pass CI when also removing the test explicitly relying on it for linux, but it's not clear to me that reflects a real-world scenario.

https://github.com/anuraaga/func-e/actions/runs/15922795255