### PR TITLE
Separate configuration, data, state and runtime directories

### DIFF
--- a/.github/workflows/commit.yaml
+++ b/.github/workflows/commit.yaml
@@ -60,8 +60,8 @@ jobs:
 
       - name: "Cache Envoy binaries"
         uses: actions/cache@v4
-        with:  # ~/.func-e/versions is cached so that we only re-download once: for TestFuncEInstall
-          path: ~/.func-e/versions
+        with:  # ~/.local/share/func-e/envoy-versions is cached so that we only re-download once: for TestFuncEInstall
+          path: ~/.local/share/func-e/envoy-versions
           key: test-${{ runner.os }}-envoy-${{ hashFiles('internal/version/last_known_envoy.txt') }}
           restore-keys: test-${{ runner.os }}-envoy-
 

--- a/CONFIG.md
+++ b/CONFIG.md
@@ -1,0 +1,58 @@
+# func-e configuration
+
+The [XDG Base Directory Specification][xdg] defines standard locations for
+user-specific files:
+
+- **Data files**: Persist across sessions, e.g. downloaded binaries
+- **State files**: Persist between restarts but non-portable, e.g. stdout.log
+- **Runtime files**: Ephemeral files, e.g. admin-address.txt
+
+func-e adopts these conventions to separate downloaded Envoy binaries, logs,
+and ephemeral admin addresses. Doing so allows library consumers like Envoy AI
+Gateway to define their own home directories under an XDG base convention.
+
+## Configuration mappings
+
+| Environment Variable  | Default Path            | API Option          |
+|-----------------------|-------------------------|---------------------|
+| `FUNC_E_CONFIG_HOME`  | `~/.config/func-e`      | `api.ConfigHome()`  |
+| `FUNC_E_DATA_HOME`    | `~/.local/share/func-e` | `api.DataHome()`    |
+| `FUNC_E_STATE_HOME`   | `~/.local/state/func-e` | `api.StateHome()`   |
+| `FUNC_E_RUNTIME_DIR`  | `/tmp/func-e-${UID}`    | `api.RuntimeDir()`  |
+| `FUNC_E_RUN_ID`       | auto-generated          | `api.RunID()`       |
+
+| File Type              | Purpose                                      | Default Path                                                                     |
+|------------------------|----------------------------------------------|----------------------------------------------------------------------------------|
+| Selected Envoy Version | Version preference (persistent, shared)      | `${FUNC_E_CONFIG_HOME}/envoy-version`                                            |
+| Envoy Binaries         | Downloaded executables (persistent, shared)  | `${FUNC_E_DATA_HOME}/envoy-versions/{version}/bin/envoy`                         |
+| Envoy Run State        | Per-run logs & config (persistent debugging) | `${FUNC_E_STATE_HOME}/envoy-runs/{runID}/stdout.log,stderr.log,config_dump.json` |
+| Admin Address Default  | Generated endpoint (ephemeral, per-run)      | `${FUNC_E_RUNTIME_DIR}/{runID}/admin-address.txt`                                |
+
+- **Correlation ID (`runID`)**: `YYYYMMDD_HHMMSS_UUU`
+  - (epoch date, time, last 3 digits of micros to allow concurrent runs)
+  - Can be customized via `FUNC_E_RUN_ID` environment variable or `--run-id` flag
+  - Custom runID cannot contain path separators (/ or \)
+  - Example: `--run-id 0` for predictable Docker/Kubernetes deployments
+- **Directory per run** isolates concurrent runs and ensures correlation
+
+## Legacy Mapping
+
+**Deprecation Warning**:
+```
+WARNING: FUNC_E_HOME is deprecated and will be removed in a future version.
+Please migrate to FUNC_E_CONFIG_HOME, FUNC_E_DATA_HOME, FUNC_E_STATE_HOME or FUNC_E_RUNTIME_DIR.
+```
+
+| File Type              | Legacy Path Pattern                           | XDG Path Pattern                                            |
+|------------------------|-----------------------------------------------|-------------------------------------------------------------|
+| Selected Envoy Version | `$FUNC_E_HOME/version`                        | `$FUNC_E_CONFIG_HOME/envoy-version`                         |
+| Envoy Binaries         | `$FUNC_E_HOME/versions/{version}/bin/envoy`   | `$FUNC_E_DATA_HOME/envoy-versions/{version}/bin/envoy`      |
+| Run Logs               | `$FUNC_E_HOME/runs/{epoch}/stdout.log`        | `$FUNC_E_STATE_HOME/envoy-runs/{runID}/stdout.log`          |
+| Admin Address          | `$FUNC_E_HOME/runs/{epoch}/admin-address.txt` | `$FUNC_E_RUNTIME_DIR/{runID}/admin-address.txt`             |
+
+These legacy patterns will be supported only when `FUNC_E_HOME` is set and will
+be removed in a future version. A file envoy.pid will not be written as it
+isn't necessary.
+
+---
+[xdg]: https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html

--- a/RATIONALE.md
+++ b/RATIONALE.md
@@ -23,3 +23,31 @@ much an emergency as if we put emulation in the critical path (ex in PR tests.)
 
 At the point when GitHub Actions supports free arm64 runners, we can simplify by removing Travis.
 Azure DevOps Pipelines already supports arm64, so it is possible GitHub Actions will in the future.
+
+## Why do we have so many environment variables for file locations?
+
+Recently, func-e is used as a library, which means its default locations need
+to support layouts that are non-default. We also want to be able to predict the
+log directory when running in Docker instead of using a timestamp in the path.
+
+This results in several config locations like this:
+
+| Environment Variable  | Default Path            | API Option          |
+|-----------------------|-------------------------|---------------------|
+| `FUNC_E_CONFIG_HOME`  | `~/.config/func-e`      | `api.ConfigHome()`  |
+| `FUNC_E_DATA_HOME`    | `~/.local/share/func-e` | `api.DataHome()`    |
+| `FUNC_E_STATE_HOME`   | `~/.local/state/func-e` | `api.StateHome()`   |
+| `FUNC_E_RUNTIME_DIR`  | `/tmp/func-e-${UID}`    | `api.RuntimeDir()`  |
+| `FUNC_E_RUN_ID`       | auto-generated          | `api.RunID()`       |
+
+These are conventional to [XDG][xdg], which makes it easier to explain to
+people. Also, XDS conventions are used by Prometheus and block/goose, so will
+be familiar to some.
+
+In summary, XDS conventions allow dependents like Envoy AI Gateway to brand
+their own directories and co-mingle its configuration and logs with those
+of func-e when it runs Envoy (the gateway process). It also allows Docker to
+export `FUNC_E_RUN_ID=0` to aid in location of key files.
+
+---
+[xdg]: https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html

--- a/USAGE.md
+++ b/USAGE.md
@@ -4,18 +4,28 @@ downloads and installs the latest version of Envoy for you.
 
 To list versions of Envoy you can use, execute `func-e versions -a`. To
 choose one, invoke `func-e use 1.35.3`. This installs into
-`$FUNC_E_HOME/versions/1.35.3`, if not already present. You may also use
-minor version, such as `func-e use 1.35`.
+`$FUNC_E_DATA_HOME/envoy-versions/1.35.3`, if not already present. You may
+also use minor version, such as `func-e use 1.35`.
 
 You may want to override `$ENVOY_VERSIONS_URL` to supply custom builds or
 otherwise control the source of Envoy binaries. When overriding, validate
 your JSON first: https://archive.tetratelabs.io/release-versions-schema.json
 
+Directory structure:
+  `$FUNC_E_CONFIG_HOME` stores configuration files
+    (default: ${HOME}/.config/func-e)
+  `$FUNC_E_DATA_HOME` stores Envoy binaries
+    (default: ${HOME}/.local/share/func-e)
+  `$FUNC_E_STATE_HOME` stores logs
+    (default: ${HOME}/.local/state/func-e)
+  `$FUNC_E_RUNTIME_DIR` stores temporary files
+    (default: /tmp/func-e-${UID})
+
 Advanced:
 `FUNC_E_PLATFORM` overrides the host OS and architecture of Envoy binaries.
 This is used when emulating another platform, e.g. x86 on Apple Silicon M1.
 Note: Changing the OS value can cause problems as Envoy has dependencies,
-such as glibc. This value must be constant within a `$FUNC_E_HOME`.
+such as glibc. This value must be constant within a `$FUNC_E_DATA_HOME`.
 
 # Commands
 
@@ -32,6 +42,11 @@ such as glibc. This value must be constant within a `$FUNC_E_HOME`.
 
 | Name | Usage | Default |
 | ---- | ----- | ------- |
-| FUNC_E_HOME | func-e home directory (location of installed versions and run archives) | ${HOME}/.func-e |
+| FUNC_E_HOME | (deprecated) func-e home directory - use --config-home, --data-home, --state-home or --runtime-dir instead |  |
+| FUNC_E_CONFIG_HOME | directory for configuration files | ${HOME}/.config/func-e |
+| FUNC_E_DATA_HOME | directory for Envoy binaries | ${HOME}/.local/share/func-e |
+| FUNC_E_STATE_HOME | directory for logs (used by run command) | ${HOME}/.local/state/func-e |
+| FUNC_E_RUNTIME_DIR | directory for temporary files (used by run command) | /tmp/func-e-${UID} |
+| FUNC_E_RUN_ID | custom run identifier for logs/runtime directories (used by run command) | auto-generated timestamp |
 | ENVOY_VERSIONS_URL | URL of Envoy versions JSON | https://archive.tetratelabs.io/envoy/envoy-versions.json |
 | FUNC_E_PLATFORM | the host OS and architecture of Envoy binaries. Ex. darwin/arm64 | $GOOS/$GOARCH |

--- a/api/run.go
+++ b/api/run.go
@@ -12,11 +12,75 @@ import (
 	"github.com/tetratelabs/func-e/internal/api"
 )
 
-// HomeDir is an absolute path which most importantly contains "versions"
-// installed from EnvoyVersionsURL. Defaults to "${HOME}/.func-e"
+// Deprecated: Use ConfigHome, DataHome, StateHome or RuntimeDir instead.
+// This function will be removed in a future version.
 func HomeDir(homeDir string) RunOption {
 	return func(o *api.RunOpts) {
-		o.HomeDir = homeDir
+		o.ConfigHome = homeDir
+		o.DataHome = homeDir
+		o.StateHome = homeDir
+		o.RuntimeDir = homeDir
+	}
+}
+
+// ConfigHome is the directory containing configuration files.
+// Defaults to "~/.config/func-e"
+//
+// Files stored here:
+// - envoy-version (selected version preference)
+func ConfigHome(configHome string) RunOption {
+	return func(o *api.RunOpts) {
+		o.ConfigHome = configHome
+	}
+}
+
+// DataHome is the directory containing downloaded Envoy binaries.
+// Defaults to "~/.local/share/func-e"
+//
+// Files stored here:
+// - envoy-versions/{version}/bin/envoy (downloaded Envoy binaries)
+func DataHome(dataHome string) RunOption {
+	return func(o *api.RunOpts) {
+		o.DataHome = dataHome
+	}
+}
+
+// StateHome is the directory containing persistent state like run logs.
+// Defaults to "~/.local/state/func-e"
+//
+// Files stored here:
+// - envoy-runs/{runID}/stdout.log,stderr.log (per-run logs)
+// - envoy-runs/{runID}/config_dump.json (Envoy configuration snapshot)
+func StateHome(stateHome string) RunOption {
+	return func(o *api.RunOpts) {
+		o.StateHome = stateHome
+	}
+}
+
+// RuntimeDir is the directory containing ephemeral runtime files.
+// Defaults to "/tmp/func-e-${UID}"
+//
+// Files stored here:
+// - {runID}/admin-address.txt (Envoy admin API endpoint)
+//
+// Note: Runtime files are ephemeral and may be cleaned up on system restart.
+func RuntimeDir(runtimeDir string) RunOption {
+	return func(o *api.RunOpts) {
+		o.RuntimeDir = runtimeDir
+	}
+}
+
+// RunID sets a custom run identifier used in StateDir and RuntimeDir paths.
+// By default, a timestamp-based runID is auto-generated (e.g., "20250115_123456_789").
+//
+// Use this to:
+// - Create predictable directories for Docker/K8s (e.g., RunID("0"))
+// - Implement custom naming schemes
+//
+// Validation: runID cannot contain path separators (/ or \)
+func RunID(runID string) RunOption {
+	return func(o *api.RunOpts) {
+		o.RunID = runID
 	}
 }
 
@@ -29,7 +93,7 @@ func EnvoyVersionsURL(envoyVersionsURL string) RunOption {
 }
 
 // EnvoyVersion overrides the version of Envoy to run. Defaults to the
-// contents of "$HomeDir/versions/version".
+// contents of "$ConfigHome/envoy-version".
 //
 // When that file is missing, it is generated from ".latestVersion" from the
 // EnvoyVersionsURL. Its value can be in full version major.minor.patch format,

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -16,11 +16,14 @@ go test -parallel 1 -v -failfast ./e2e
 When run via `make`, `func-e` is built on-demand by `$(current_binary)` target (same as `make build`).
 Ex. `$PWD/build/func-e_darwin_arm64/func-e`
 
-It is also a good idea to override `FUNC_E_HOME` when running e2e, since by default it uses `$HOME/.func-e`.
+It is also a good idea to override the data directories when running e2e to avoid interfering with your local environment.
+The defaults are `~/.local/share/func-e`, `~/.local/state/func-e` and `/tmp/func-e-${UID}`.
 
 ```bash
-FUNC_E_HOME=/tmp/test make e2e
+FUNC_E_DATA_HOME=/tmp/test FUNC_E_STATE_HOME=/tmp/test FUNC_E_RUNTIME_DIR=/tmp/test make e2e
 ```
+
+Note: The deprecated `FUNC_E_HOME` environment variable is still supported for backwards compatibility.
 
 ## Envoy version list
 If the `func-e` version is a snapshot and "envoy-versions.json" exists, tests run against the local. This allows local

--- a/e2e/func-e_run_test.go
+++ b/e2e/func-e_run_test.go
@@ -21,8 +21,12 @@ func TestRun_LogWarn(t *testing.T) {
 	e2e.TestRun_LogWarn(t.Context(), t, funcEFactory{})
 }
 
-func TestRun_RunDirectory(t *testing.T) {
-	e2e.TestRun_RunDirectory(t.Context(), t, funcEFactory{})
+func TestRun_RunDir(t *testing.T) {
+	// For binary e2e tests, state directory is controlled via FUNC_E_STATE_HOME env var
+	// (CLI layer), not library API options like api.StateHome().
+	stateDir := t.TempDir()
+	t.Setenv("FUNC_E_STATE_HOME", stateDir)
+	e2e.TestRun_RunDir(t.Context(), t, funcEFactory{}, stateDir)
 }
 
 func TestRun_InvalidConfig(t *testing.T) {
@@ -35,4 +39,8 @@ func TestRun_StaticFile(t *testing.T) {
 
 func TestRun_CtrlCs(t *testing.T) {
 	e2e.TestRun_CtrlCs(t.Context(), t, funcEFactory{})
+}
+
+func TestRun_LegacyHomeDir(t *testing.T) {
+	e2e.TestRun_LegacyHomeDir(t.Context(), t, funcEFactory{})
 }

--- a/e2e/func-e_versions_test.go
+++ b/e2e/func-e_versions_test.go
@@ -15,9 +15,9 @@ import (
 )
 
 func TestFuncEVersions_NothingYet(t *testing.T) {
-	homeDir := t.TempDir()
+	dataHome := t.TempDir()
 
-	stdout, stderr, err := funcEExec(t.Context(), "--home-dir", homeDir, "versions")
+	stdout, stderr, err := funcEExec(t.Context(), "--data-home", dataHome, "versions")
 
 	require.NoError(t, err)
 	require.Empty(t, stdout)

--- a/experimental/admin/admin.go
+++ b/experimental/admin/admin.go
@@ -18,16 +18,19 @@ type AdminClient = internalapi.AdminClient
 
 // NewAdminClient returns an AdminClient if `funcEPid` has a child envoy process.
 func NewAdminClient(ctx context.Context, funcEPid int) (AdminClient, error) {
-	// Poll for the run directory and admin address path from the Envoy process command line
-	runDir, adminAddressPath, err := admin.PollAdminAddressPathAndRunDir(ctx, funcEPid)
+	// Poll for the admin address path from the Envoy process command line
+	_, adminAddressPath, err := admin.PollEnvoyPidAndAdminAddressPath(ctx, funcEPid)
 	if err != nil {
 		return nil, err
 	}
-	return admin.NewAdminClient(ctx, runDir, adminAddressPath)
+	return admin.NewAdminClient(ctx, adminAddressPath)
 }
 
 // StartupHook runs once the Envoy admin server is ready. Configure this
 // via the WithStartupHook api.RunOption.
+//
+// The hook receives the AdminClient and runID. The runID is unique to this run
+// and can be used to construct file paths as needed.
 //
 // Note: Startup hooks are considered mandatory and will stop the run with
 // error if failed. If your hook is optional, rescue panics and log your own

--- a/internal/api/admin.go
+++ b/internal/api/admin.go
@@ -18,12 +18,6 @@ type AdminClient interface {
 	// Port returns the Envoy admin API port.
 	Port() int
 
-	// Pid returns the Envoy process ID.
-	Pid() int32
-
-	// RunDir returns the directory where files like stdout.log are written to.
-	RunDir() string
-
 	// Get returns the content at the given path or an error if != 200
 	Get(ctx context.Context, path string) ([]byte, error)
 
@@ -45,7 +39,10 @@ type AdminClient interface {
 
 // StartupHook runs once the Envoy admin server is ready.
 //
+// The hook receives the AdminClient and runID. The runID is unique to this run
+// and can be used to construct file paths as needed.
+//
 // Note: Startup hooks are considered mandatory and will stop the run with
 // error if failed. If your hook is optional, rescue panics and log your own
 // errors.
-type StartupHook func(ctx context.Context, adminClient AdminClient) error
+type StartupHook func(ctx context.Context, adminClient AdminClient, runID string) error

--- a/internal/api/opts.go
+++ b/internal/api/opts.go
@@ -11,7 +11,11 @@ import (
 
 // RunOpts holds the configuration set by RunOptions.
 type RunOpts struct {
-	HomeDir          string
+	ConfigHome       string
+	DataHome         string
+	StateHome        string
+	RuntimeDir       string
+	RunID            string // Optional: custom run identifier for StateDir and RuntimeDir paths
 	EnvoyVersion     string
 	EnvoyVersionsURL string
 	Out              io.Writer

--- a/internal/cmd/app.go
+++ b/internal/cmd/app.go
@@ -16,8 +16,8 @@ import (
 // NewApp create a new root command. The globals.GlobalOpts parameter allows tests to scope overrides, which avoids
 // having to define a flag for everything needed in tests.
 func NewApp(o *globals.GlobalOpts) *cli.App {
-	var envoyVersionsURL, homeDir, platform string
-	lastKnownEnvoyPath := fmt.Sprintf("`$FUNC_E_HOME/versions/%s`", version.LastKnownEnvoy)
+	var envoyVersionsURL, homeDir, configHome, dataHome, stateHome, runtimeDir, platform, runID string
+	lastKnownEnvoyPath := fmt.Sprintf("`$FUNC_E_DATA_HOME/envoy-versions/%s`", version.LastKnownEnvoy)
 
 	app := cli.NewApp()
 	app.Name = "func-e"
@@ -29,26 +29,70 @@ downloads and installs the latest version of Envoy for you.
 
 To list versions of Envoy you can use, execute ` + "`func-e versions -a`" + `. To
 choose one, invoke ` + fmt.Sprintf("`func-e use %s`", version.LastKnownEnvoy) + `. This installs into
-` + lastKnownEnvoyPath + `, if not already present. You may also use
-minor version, such as ` + fmt.Sprintf("`func-e use %s`", version.LastKnownEnvoyMinor) + `.
+` + lastKnownEnvoyPath + `, if not already present. You may
+also use minor version, such as ` + fmt.Sprintf("`func-e use %s`", version.LastKnownEnvoyMinor) + `.
 
 You may want to override ` + "`$ENVOY_VERSIONS_URL`" + ` to supply custom builds or
 otherwise control the source of Envoy binaries. When overriding, validate
 your JSON first: ` + globals.DefaultEnvoyVersionsSchemaURL + `
 
+Directory structure:
+  ` + "`$FUNC_E_CONFIG_HOME`" + ` stores configuration files
+    (default: ` + globals.DefaultConfigHome + `)
+  ` + "`$FUNC_E_DATA_HOME`" + ` stores Envoy binaries
+    (default: ` + globals.DefaultDataHome + `)
+  ` + "`$FUNC_E_STATE_HOME`" + ` stores logs
+    (default: ` + globals.DefaultStateHome + `)
+  ` + "`$FUNC_E_RUNTIME_DIR`" + ` stores temporary files
+    (default: ` + globals.DefaultRuntimeDir + `)
+
 Advanced:
 ` + "`FUNC_E_PLATFORM`" + ` overrides the host OS and architecture of Envoy binaries.
 This is used when emulating another platform, e.g. x86 on Apple Silicon M1.
 Note: Changing the OS value can cause problems as Envoy has dependencies,
-such as glibc. This value must be constant within a ` + "`$FUNC_E_HOME`" + `.`
+such as glibc. This value must be constant within a ` + "`$FUNC_E_DATA_HOME`" + `.`
 	app.Version = o.Version
 	app.Flags = []cli.Flag{
 		&cli.StringFlag{
 			Name:        "home-dir",
-			Usage:       "func-e home directory (location of installed versions and run archives)",
-			DefaultText: globals.DefaultHomeDir,
+			Usage:       "(deprecated) func-e home directory - use --config-home, --data-home, --state-home or --runtime-dir instead",
 			Destination: &homeDir,
 			EnvVars:     []string{"FUNC_E_HOME"},
+		},
+		&cli.StringFlag{
+			Name:        "config-home",
+			Usage:       "directory for configuration files",
+			DefaultText: globals.DefaultConfigHome,
+			Destination: &configHome,
+			EnvVars:     []string{"FUNC_E_CONFIG_HOME"},
+		},
+		&cli.StringFlag{
+			Name:        "data-home",
+			Usage:       "directory for Envoy binaries",
+			DefaultText: globals.DefaultDataHome,
+			Destination: &dataHome,
+			EnvVars:     []string{"FUNC_E_DATA_HOME"},
+		},
+		&cli.StringFlag{
+			Name:        "state-home",
+			Usage:       "directory for logs (used by run command)",
+			DefaultText: globals.DefaultStateHome,
+			Destination: &stateHome,
+			EnvVars:     []string{"FUNC_E_STATE_HOME"},
+		},
+		&cli.StringFlag{
+			Name:        "runtime-dir",
+			Usage:       "directory for temporary files (used by run command)",
+			DefaultText: globals.DefaultRuntimeDir,
+			Destination: &runtimeDir,
+			EnvVars:     []string{"FUNC_E_RUNTIME_DIR"},
+		},
+		&cli.StringFlag{
+			Name:        "run-id",
+			Usage:       "custom run identifier for logs/runtime directories (used by run command)",
+			DefaultText: "auto-generated timestamp",
+			Destination: &runID,
+			EnvVars:     []string{"FUNC_E_RUN_ID"},
 		},
 		&cli.StringFlag{
 			Name:        "envoy-versions-url",
@@ -66,7 +110,13 @@ such as glibc. This value must be constant within a ` + "`$FUNC_E_HOME`" + `.`
 		},
 	}
 	app.Before = func(c *cli.Context) error {
-		if err := runtime.InitializeGlobalOpts(o, envoyVersionsURL, homeDir, platform); err != nil {
+		// Emit deprecation warning if $FUNC_E_HOME is set
+		if homeDir != "" {
+			fmt.Fprintln(c.App.ErrWriter, "WARNING: $FUNC_E_HOME (--home-dir) is deprecated and will be removed in a future version.") //nolint:errcheck
+			fmt.Fprintln(c.App.ErrWriter, "Please use --config-home, --data-home, --state-home or --runtime-dir instead.")             //nolint:errcheck
+		}
+
+		if err := runtime.InitializeGlobalOpts(o, envoyVersionsURL, homeDir, configHome, dataHome, stateHome, runtimeDir, platform, runID); err != nil {
 			return NewValidationError(err.Error())
 		}
 		return nil

--- a/internal/cmd/app_test.go
+++ b/internal/cmd/app_test.go
@@ -6,7 +6,6 @@ package cmd_test
 import (
 	"bytes"
 	"io"
-	"os"
 	"os/user"
 	"path/filepath"
 	"testing"
@@ -20,6 +19,9 @@ import (
 	"github.com/tetratelabs/func-e/internal/test"
 	"github.com/tetratelabs/func-e/internal/version"
 )
+
+const deprecationWarning = "WARNING: $FUNC_E_HOME (--home-dir) is deprecated and will be removed in a future version.\n" +
+	"Please use --config-home, --data-home, --state-home or --runtime-dir instead.\n"
 
 func TestFuncEValidateArgs(t *testing.T) {
 	tests := []struct {
@@ -44,10 +46,11 @@ func TestFuncEValidateArgs(t *testing.T) {
 
 func TestHomeDir(t *testing.T) {
 	type testCase struct {
-		name     string
-		args     []string
-		setup    func()
-		expected string
+		name           string
+		args           []string
+		setup          func()
+		expected       string
+		expectedStderr string
 	}
 
 	u, err := user.Current()
@@ -58,22 +61,24 @@ func TestHomeDir(t *testing.T) {
 
 	tests := []testCase{ // we don't test default as that depends on the runtime env
 		{
-			name:     "default is ~/.func-e",
+			name:     "default",
 			args:     []string{"func-e"},
-			expected: filepath.Join(u.HomeDir, ".func-e"),
+			expected: filepath.Join(u.HomeDir, ".local/share/func-e"),
 		},
 		{
-			name: "FUNC_E_HOME env",
+			name: "FUNC_E_HOME env (legacy mode)",
 			args: []string{"func-e"},
 			setup: func() {
 				t.Setenv("FUNC_E_HOME", alt1)
 			},
-			expected: alt1,
+			expected:       alt1,
+			expectedStderr: deprecationWarning,
 		},
 		{
-			name:     "--home-dir arg",
-			args:     []string{"func-e", "--home-dir", alt1},
-			expected: alt1,
+			name:           "--home-dir arg (legacy mode)",
+			args:           []string{"func-e", "--home-dir", alt1},
+			expected:       alt1,
+			expectedStderr: deprecationWarning,
 		},
 		{
 			name: "prioritizes --home-dir arg over FUNC_E_HOME env",
@@ -81,7 +86,8 @@ func TestHomeDir(t *testing.T) {
 			setup: func() {
 				t.Setenv("FUNC_E_HOME", alt2)
 			},
-			expected: alt1,
+			expected:       alt1,
+			expectedStderr: deprecationWarning,
 		},
 	}
 
@@ -92,10 +98,166 @@ func TestHomeDir(t *testing.T) {
 			}
 
 			o := &globals.GlobalOpts{}
-			err := runTestCommand(t, o, tc.args)
+			c, _, stderr := newApp(o)
+			c.Commands = append(c.Commands, &cli.Command{Name: "test", Action: func(_ *cli.Context) error {
+				return nil
+			}})
+
+			err := c.Run(append(tc.args, "test"))
 
 			require.NoError(t, err)
-			require.Equal(t, tc.expected, o.HomeDir)
+			// In legacy mode, all three directories point to the same location
+			require.Equal(t, tc.expected, o.DataHome)
+
+			require.Equal(t, tc.expectedStderr, stderr.String())
+		})
+	}
+}
+
+func TestDataHome(t *testing.T) {
+	u, err := user.Current()
+	require.NoError(t, err)
+
+	testDirConfig(t, dirConfigTest{
+		envVar:      "FUNC_E_DATA_HOME",
+		flag:        "--data-home",
+		suffix:      "data",
+		defaultPath: filepath.Join(u.HomeDir, ".local/share/func-e"),
+		accessor:    func(o *globals.GlobalOpts) string { return o.DataHome },
+	})
+}
+
+func TestStateHome(t *testing.T) {
+	u, err := user.Current()
+	require.NoError(t, err)
+
+	testDirConfig(t, dirConfigTest{
+		envVar:      "FUNC_E_STATE_HOME",
+		flag:        "--state-home",
+		suffix:      "state",
+		defaultPath: filepath.Join(u.HomeDir, ".local/state/func-e"),
+		accessor:    func(o *globals.GlobalOpts) string { return o.StateHome },
+	})
+}
+
+type dirConfigTest struct {
+	envVar      string
+	flag        string
+	suffix      string
+	defaultPath string
+	accessor    func(*globals.GlobalOpts) string
+}
+
+func testDirConfig(t *testing.T, cfg dirConfigTest) {
+	type testCase struct {
+		name     string
+		args     []string
+		env      map[string]string
+		expected string
+	}
+
+	u, err := user.Current()
+	require.NoError(t, err)
+
+	alt1 := filepath.Join(u.HomeDir, "alt-"+cfg.suffix)
+	alt2 := filepath.Join(u.HomeDir, "alt-"+cfg.suffix+"-2")
+
+	tests := []testCase{
+		{
+			name:     "default",
+			args:     []string{"func-e"},
+			expected: cfg.defaultPath,
+		},
+		{
+			name: cfg.envVar + " env",
+			args: []string{"func-e"},
+			env: map[string]string{
+				cfg.envVar: alt1,
+			},
+			expected: alt1,
+		},
+		{
+			name:     cfg.flag + " flag",
+			args:     []string{"func-e", cfg.flag, alt1},
+			expected: alt1,
+		},
+		{
+			name: "prioritizes " + cfg.flag + " arg over " + cfg.envVar + " env",
+			args: []string{"func-e", cfg.flag, alt1},
+			env: map[string]string{
+				cfg.envVar: alt2,
+			},
+			expected: alt1,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			for k, v := range tc.env {
+				t.Setenv(k, v)
+			}
+
+			o := &globals.GlobalOpts{}
+			err := runTestCommand(t, o, tc.args)
+			require.NoError(t, err)
+			require.Equal(t, tc.expected, cfg.accessor(o))
+		})
+	}
+}
+
+func TestRuntimeDir(t *testing.T) {
+	type testCase struct {
+		name     string
+		args     []string
+		env      map[string]string
+		expected string
+	}
+
+	alt1 := "/tmp/alt-runtime"
+	alt2 := "/tmp/alt-runtime-2"
+
+	u, err := user.Current()
+	require.NoError(t, err)
+
+	tests := []testCase{
+		{
+			name:     "default is /tmp/func-e-${UID}",
+			args:     []string{"func-e"},
+			expected: "/tmp/func-e-" + u.Uid,
+		},
+		{
+			name: "FUNC_E_RUNTIME_DIR env",
+			args: []string{"func-e"},
+			env: map[string]string{
+				"FUNC_E_RUNTIME_DIR": alt1,
+			},
+			expected: alt1,
+		},
+		{
+			name:     "--runtime-dir flag",
+			args:     []string{"func-e", "--runtime-dir", alt1},
+			expected: alt1,
+		},
+		{
+			name: "prioritizes --runtime-dir arg over FUNC_E_RUNTIME_DIR env",
+			args: []string{"func-e", "--runtime-dir", alt1},
+			env: map[string]string{
+				"FUNC_E_RUNTIME_DIR": alt2,
+			},
+			expected: alt1,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			for k, v := range tc.env {
+				t.Setenv(k, v)
+			}
+
+			o := &globals.GlobalOpts{}
+			err := runTestCommand(t, o, tc.args)
+			require.NoError(t, err)
+			require.Equal(t, tc.expected, o.RuntimeDir)
 		})
 	}
 }
@@ -104,7 +266,7 @@ func TestPlatformArg(t *testing.T) {
 	type testCase struct {
 		name     string
 		args     []string
-		setup    func()
+		env      map[string]string
 		expected version.Platform
 	}
 
@@ -112,8 +274,8 @@ func TestPlatformArg(t *testing.T) {
 		{
 			name: "FUNC_E_PLATFORM env",
 			args: []string{"func-e"},
-			setup: func() {
-				t.Setenv("FUNC_E_PLATFORM", "linux/amd64")
+			env: map[string]string{
+				"FUNC_E_PLATFORM": "linux/amd64",
 			},
 			expected: version.Platform("linux/amd64"),
 		},
@@ -126,8 +288,8 @@ func TestPlatformArg(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			if tc.setup != nil {
-				tc.setup()
+			for k, v := range tc.env {
+				t.Setenv(k, v)
 			}
 
 			o := &globals.GlobalOpts{}
@@ -142,7 +304,7 @@ func TestEnvoyVersionsURL(t *testing.T) {
 	type testCase struct {
 		name     string
 		args     []string
-		setup    func()
+		env      map[string]string
 		expected string
 	}
 
@@ -155,8 +317,8 @@ func TestEnvoyVersionsURL(t *testing.T) {
 		{
 			name: "ENVOY_VERSIONS_URL env",
 			args: []string{"func-e"},
-			setup: func() {
-				t.Setenv("ENVOY_VERSIONS_URL", "http://ENVOY_VERSIONS_URL/env")
+			env: map[string]string{
+				"ENVOY_VERSIONS_URL": "http://ENVOY_VERSIONS_URL/env",
 			},
 			expected: "http://ENVOY_VERSIONS_URL/env",
 		},
@@ -168,8 +330,8 @@ func TestEnvoyVersionsURL(t *testing.T) {
 		{
 			name: "prioritizes --envoy-versions-url arg over ENVOY_VERSIONS_URL env",
 			args: []string{"func-e", "--envoy-versions-url", "http://versions/arg"},
-			setup: func() {
-				t.Setenv("ENVOY_VERSIONS_URL", "http://ENVOY_VERSIONS_URL/env")
+			env: map[string]string{
+				"ENVOY_VERSIONS_URL": "http://ENVOY_VERSIONS_URL/env",
 			},
 			expected: "http://versions/arg",
 		},
@@ -177,8 +339,8 @@ func TestEnvoyVersionsURL(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			if tc.setup != nil {
-				tc.setup()
+			for k, v := range tc.env {
+				t.Setenv(k, v)
 			}
 
 			o := &globals.GlobalOpts{}
@@ -221,15 +383,16 @@ func runTestCommand(t *testing.T, o *globals.GlobalOpts, args []string) error {
 func setupTest(t *testing.T) *globals.GlobalOpts {
 	result := globals.GlobalOpts{}
 	result.EnvoyVersion = version.LastKnownEnvoy
+	result.Platform = globals.DefaultPlatform
 	result.Out = io.Discard // ignore logging by default
 	result.EnvoyOut = io.Discard
 	result.EnvoyErr = io.Discard
 
-	tempDir := t.TempDir()
-
-	result.HomeDir = filepath.Join(tempDir, "envoy_home")
-	err := os.Mkdir(result.HomeDir, 0o700)
-	require.NoError(t, err, `error creating directory: %s`, result.HomeDir)
+	// Use separate temp directories for XDG convention
+	result.ConfigHome = t.TempDir()
+	result.DataHome = t.TempDir()
+	result.StateHome = t.TempDir()
+	result.RuntimeDir = t.TempDir()
 
 	versionsServer := test.RequireEnvoyVersionsTestServer(t, version.LastKnownEnvoy)
 	result.EnvoyVersionsURL = versionsServer.URL + "/envoy-versions.json"

--- a/internal/cmd/run.go
+++ b/internal/cmd/run.go
@@ -15,7 +15,6 @@ import (
 
 // NewRunCmd create a command responsible for starting an Envoy process
 func NewRunCmd(o *globals.GlobalOpts) *cli.Command {
-	runDirectoryExpression := "$FUNC_E_HOME/runs/$epochtime"
 	cmd := &cli.Command{
 		Name:            "run",
 		Usage:           "Run Envoy with the given [arguments...] until interrupted",
@@ -30,8 +29,8 @@ The version to use is downloaded and installed, if necessary.
 Envoy interprets the '[arguments...]' and runs in the current working
 directory (aka $PWD) until func-e is interrupted (ex Ctrl+C, Ctrl+Break).
 
-Envoy's process ID and console output write to "envoy.pid", stdout.log" and
-"stderr.log" in the run directory (` + fmt.Sprintf("`%s`", runDirectoryExpression) + `).`,
+Envoy's console output writes to "stdout.log" and "stderr.log" in the run directory
+(` + fmt.Sprintf("`%s`", globals.DefaultStateHome) + `/envoy-logs/{runID}).`,
 		Before: func(c *cli.Context) error {
 			if err := runtime.EnsureEnvoyVersion(c.Context, o); err != nil {
 				return NewValidationError(err.Error())

--- a/internal/cmd/testdata/func-e_help.txt
+++ b/internal/cmd/testdata/func-e_help.txt
@@ -7,18 +7,28 @@ USAGE:
 
    To list versions of Envoy you can use, execute `func-e versions -a`. To
    choose one, invoke `func-e use 1.35.3`. This installs into
-   `$FUNC_E_HOME/versions/1.35.3`, if not already present. You may also use
-   minor version, such as `func-e use 1.35`.
+   `$FUNC_E_DATA_HOME/envoy-versions/1.35.3`, if not already present. You may
+   also use minor version, such as `func-e use 1.35`.
 
    You may want to override `$ENVOY_VERSIONS_URL` to supply custom builds or
    otherwise control the source of Envoy binaries. When overriding, validate
    your JSON first: https://archive.tetratelabs.io/release-versions-schema.json
 
+   Directory structure:
+     `$FUNC_E_CONFIG_HOME` stores configuration files
+       (default: ${HOME}/.config/func-e)
+     `$FUNC_E_DATA_HOME` stores Envoy binaries
+       (default: ${HOME}/.local/share/func-e)
+     `$FUNC_E_STATE_HOME` stores logs
+       (default: ${HOME}/.local/state/func-e)
+     `$FUNC_E_RUNTIME_DIR` stores temporary files
+       (default: /tmp/func-e-${UID})
+
    Advanced:
    `FUNC_E_PLATFORM` overrides the host OS and architecture of Envoy binaries.
    This is used when emulating another platform, e.g. x86 on Apple Silicon M1.
    Note: Changing the OS value can cause problems as Envoy has dependencies,
-   such as glibc. This value must be constant within a `$FUNC_E_HOME`.
+   such as glibc. This value must be constant within a `$FUNC_E_DATA_HOME`.
 
 VERSION:
    1.0
@@ -31,7 +41,12 @@ COMMANDS:
    which     Prints the path to the Envoy binary used by the "run" command
 
 GLOBAL OPTIONS:
-   --home-dir value            func-e home directory (location of installed versions and run archives) (default: ${HOME}/.func-e) [$FUNC_E_HOME]
+   --home-dir value            (deprecated) func-e home directory - use --config-home, --data-home, --state-home or --runtime-dir instead [$FUNC_E_HOME]
+   --config-home value         directory for configuration files (default: ${HOME}/.config/func-e) [$FUNC_E_CONFIG_HOME]
+   --data-home value           directory for Envoy binaries (default: ${HOME}/.local/share/func-e) [$FUNC_E_DATA_HOME]
+   --state-home value          directory for logs (used by run command) (default: ${HOME}/.local/state/func-e) [$FUNC_E_STATE_HOME]
+   --runtime-dir value         directory for temporary files (used by run command) (default: /tmp/func-e-${UID}) [$FUNC_E_RUNTIME_DIR]
+   --run-id value              custom run identifier for logs/runtime directories (used by run command) (default: auto-generated timestamp) [$FUNC_E_RUN_ID]
    --envoy-versions-url value  URL of Envoy versions JSON (default: https://archive.tetratelabs.io/envoy/envoy-versions.json) [$ENVOY_VERSIONS_URL]
    --platform value            the host OS and architecture of Envoy binaries. Ex. darwin/arm64 (default: $GOOS/$GOARCH) [$FUNC_E_PLATFORM]
    --version, -v               print the version

--- a/internal/cmd/testdata/func-e_run_help.txt
+++ b/internal/cmd/testdata/func-e_run_help.txt
@@ -9,12 +9,12 @@ DESCRIPTION:
 
    The first version in the below is run, controllable by the "use" command:
    ```
-   $ENVOY_VERSION, $PWD/.envoy-version, $FUNC_E_HOME/version
+   $ENVOY_VERSION, $PWD/.envoy-version, $FUNC_E_CONFIG_HOME/envoy-version
    ```
    The version to use is downloaded and installed, if necessary.
 
    Envoy interprets the '[arguments...]' and runs in the current working
    directory (aka $PWD) until func-e is interrupted (ex Ctrl+C, Ctrl+Break).
 
-   Envoy's process ID and console output write to "envoy.pid", stdout.log" and
-   "stderr.log" in the run directory (`$FUNC_E_HOME/runs/$epochtime`).
+   Envoy's console output writes to "stdout.log" and "stderr.log" in the run directory
+   (`${HOME}/.local/state/func-e`/envoy-logs/{runID}).

--- a/internal/cmd/testdata/func-e_use_help.txt
+++ b/internal/cmd/testdata/func-e_use_help.txt
@@ -6,12 +6,12 @@ USAGE:
 
 DESCRIPTION:
    The '[version]' is from the "versions -a" command.
-   The Envoy [version] installs on-demand into $FUNC_E_HOME/versions/[version]
+   The Envoy [version] installs on-demand into $FUNC_E_DATA_HOME/envoy-versions/[version]
    if needed. You may also exclude the patch component of the [version]
    to use the latest patch version or to download the binary if it is
    not already downloaded.
 
-   This updates $PWD/.envoy-version or $FUNC_E_HOME/version with [version],
+   This updates $PWD/.envoy-version or $FUNC_E_CONFIG_HOME/envoy-version with [version],
    depending on which is present.
 
    Example:

--- a/internal/cmd/use.go
+++ b/internal/cmd/use.go
@@ -16,9 +16,9 @@ import (
 
 // NewUseCmd create a command responsible for downloading and extracting Envoy
 func NewUseCmd(o *globals.GlobalOpts) *cli.Command {
-	versionsDir := "$FUNC_E_HOME/versions/"
+	versionsDir := "$FUNC_E_DATA_HOME/envoy-versions/"
 	currentVersionWorkingDirFile := envoy.CurrentVersionWorkingDirFile
-	currentVersionHomeDirFile := envoy.CurrentVersionHomeDirFile
+	currentVersionConfigFile := envoy.CurrentVersionConfigFile
 
 	var v version.Version
 	return &cli.Command{
@@ -36,7 +36,7 @@ depending on which is present.
 
 Example:
 $ func-e use %s
-$ func-e use %s`, currentVersionWorkingDirFile, currentVersionHomeDirFile, version.LastKnownEnvoy, version.LastKnownEnvoyMinor),
+$ func-e use %s`, currentVersionWorkingDirFile, currentVersionConfigFile, version.LastKnownEnvoy, version.LastKnownEnvoyMinor),
 		Before: func(c *cli.Context) (err error) {
 			if v, err = version.NewVersion("[version] argument", c.Args().First()); err != nil {
 				err = NewValidationError(err.Error())
@@ -53,7 +53,7 @@ $ func-e use %s`, currentVersionWorkingDirFile, currentVersionHomeDirFile, versi
 				return err
 			}
 			// Persist the input precision. This allows those specifying a MinorVersion to always get the latest patch.
-			return envoy.WriteCurrentVersion(v, o.HomeDir)
+			return envoy.WriteCurrentVersion(v, o.ConfigHome, o.EnvoyVersionFile())
 		},
 		CustomHelpTemplate: cli.CommandHelpTemplate,
 	}

--- a/internal/cmd/use_test.go
+++ b/internal/cmd/use_test.go
@@ -55,10 +55,10 @@ func TestFuncEUse_InstallsAndWritesHomeVersion(t *testing.T) {
 	require.NoError(t, c.Run([]string{"func-e", "use", evs}))
 
 	// The binary was installed
-	require.FileExists(t, filepath.Join(o.HomeDir, "versions", evs, "bin", "envoy"+""))
+	require.FileExists(t, filepath.Join(o.DataHome, "envoy-versions", evs, "bin", "envoy"+""))
 
 	// The current version was written
-	f, err := os.ReadFile(filepath.Join(o.HomeDir, "version"))
+	f, err := os.ReadFile(filepath.Join(o.ConfigHome, "envoy-version"))
 	require.NoError(t, err)
 	require.Equal(t, evs, string(f))
 }
@@ -90,14 +90,14 @@ func TestFuncEUse_InstallMinorVersion(t *testing.T) {
 		{
 			name: "not-upgraded",
 			firstVersions: availableVersions{
-				latestPatch: "3",
-				versions:    []version.PatchVersion{version.PatchVersion("1.12.3")},
+				latestPatch: "5",
+				versions:    []version.PatchVersion{version.PatchVersion("1.29.5")},
 			},
 			secondVersions: availableVersions{
-				latestPatch: "3",
-				versions:    []version.PatchVersion{version.PatchVersion("1.12.3")},
+				latestPatch: "5",
+				versions:    []version.PatchVersion{version.PatchVersion("1.29.5")},
 			},
-			minorVersion: "1.12",
+			minorVersion: "1.29",
 		},
 	}
 
@@ -109,7 +109,7 @@ func TestFuncEUse_InstallMinorVersion(t *testing.T) {
 
 			c, _, _ := newApp(o)
 			require.NoError(t, c.Run([]string{"func-e", "use", tc.minorVersion}))
-			f, err := os.ReadFile(filepath.Join(o.HomeDir, "version"))
+			f, err := os.ReadFile(filepath.Join(o.ConfigHome, "envoy-version"))
 			require.NoError(t, err)
 			require.Equal(t, tc.minorVersion, string(f))
 
@@ -117,7 +117,7 @@ func TestFuncEUse_InstallMinorVersion(t *testing.T) {
 			o.EnvoyVersion = ""
 			c, stdout, stderr := newApp(o)
 			require.NoError(t, c.Run([]string{"func-e", "which"}))
-			envoyPath := filepath.Join(o.HomeDir, "versions", tc.minorVersion+"."+tc.firstVersions.latestPatch, "bin", "envoy"+"")
+			envoyPath := filepath.Join(o.DataHome, "envoy-versions", tc.minorVersion+"."+tc.firstVersions.latestPatch, "bin", "envoy"+"")
 			require.Equal(t, fmt.Sprintf("%s\n", envoyPath), stdout.String())
 			require.Empty(t, stderr)
 
@@ -126,7 +126,7 @@ func TestFuncEUse_InstallMinorVersion(t *testing.T) {
 			require.NoError(t, err)
 			c, _, _ = newApp(o)
 			require.NoError(t, c.Run([]string{"func-e", "use", tc.minorVersion}))
-			f, err = os.ReadFile(filepath.Join(o.HomeDir, "version"))
+			f, err = os.ReadFile(filepath.Join(o.ConfigHome, "envoy-version"))
 			require.NoError(t, err)
 			require.Equal(t, tc.minorVersion, string(f))
 
@@ -134,7 +134,7 @@ func TestFuncEUse_InstallMinorVersion(t *testing.T) {
 			o.EnvoyVersion = ""
 			c, stdout, stderr = newApp(o)
 			require.NoError(t, c.Run([]string{"func-e", "which"}))
-			envoyPath = filepath.Join(o.HomeDir, "versions", tc.minorVersion+"."+tc.secondVersions.latestPatch, "bin", "envoy"+"")
+			envoyPath = filepath.Join(o.DataHome, "envoy-versions", tc.minorVersion+"."+tc.secondVersions.latestPatch, "bin", "envoy"+"")
 			require.Equal(t, fmt.Sprintf("%s\n", envoyPath), stdout.String())
 			require.Empty(t, stderr)
 		})
@@ -145,7 +145,7 @@ func TestFuncEUse_InstallMinorVersionCheckLatestPatchFailed(t *testing.T) {
 	o := setupTest(t)
 
 	// The initial version to be installed.
-	minorVersion := "1.12"
+	minorVersion := "1.29"
 	latestPatch := "3"
 	initial := availableVersions{
 		latestPatch: latestPatch,
@@ -158,14 +158,14 @@ func TestFuncEUse_InstallMinorVersionCheckLatestPatchFailed(t *testing.T) {
 
 	c, _, _ := newApp(o)
 	require.NoError(t, c.Run([]string{"func-e", "use", minorVersion}))
-	f, err := os.ReadFile(filepath.Join(o.HomeDir, "version"))
+	f, err := os.ReadFile(filepath.Join(o.ConfigHome, "envoy-version"))
 	require.NoError(t, err)
 	require.Equal(t, minorVersion, string(f))
 
 	o.EnvoyVersion = ""
 	c, stdout, stderr := newApp(o)
 	require.NoError(t, c.Run([]string{"func-e", "which"}))
-	envoyPath := filepath.Join(o.HomeDir, "versions", minorVersion+"."+latestPatch, "bin", "envoy"+"")
+	envoyPath := filepath.Join(o.DataHome, "envoy-versions", minorVersion+"."+latestPatch, "bin", "envoy"+"")
 	require.Equal(t, fmt.Sprintf("%s\n", envoyPath), stdout.String())
 	require.Empty(t, stderr)
 
@@ -174,7 +174,7 @@ func TestFuncEUse_InstallMinorVersionCheckLatestPatchFailed(t *testing.T) {
 	}
 	c, _, _ = newApp(o)
 	require.NoError(t, c.Run([]string{"func-e", "use", minorVersion}))
-	f, err = os.ReadFile(filepath.Join(o.HomeDir, "version"))
+	f, err = os.ReadFile(filepath.Join(o.ConfigHome, "envoy-version"))
 	require.NoError(t, err)
 	require.Equal(t, minorVersion, string(f))
 
@@ -182,7 +182,7 @@ func TestFuncEUse_InstallMinorVersionCheckLatestPatchFailed(t *testing.T) {
 	c, stdout, stderr = newApp(o)
 	require.NoError(t, c.Run([]string{"func-e", "which"}))
 	// The path points to the latest installed version.
-	envoyPath = filepath.Join(o.HomeDir, "versions", minorVersion+"."+latestPatch, "bin", "envoy"+"")
+	envoyPath = filepath.Join(o.DataHome, "envoy-versions", minorVersion+"."+latestPatch, "bin", "envoy"+"")
 	t.Log(stdout.String())
 	require.Equal(t, fmt.Sprintf("%s\n", envoyPath), stdout.String())
 	require.Empty(t, stderr)

--- a/internal/cmd/versions.go
+++ b/internal/cmd/versions.go
@@ -6,7 +6,6 @@ package cmd
 import (
 	"fmt"
 	"os"
-	"path/filepath"
 	"sort"
 	"text/tabwriter"
 	"time"
@@ -31,12 +30,12 @@ func NewVersionsCmd(o *globals.GlobalOpts) *cli.Command {
 			},
 		},
 		Action: func(c *cli.Context) error {
-			rows, err := getInstalledVersions(o.HomeDir)
+			rows, err := getInstalledVersions(o.EnvoyVersionsDir())
 			if err != nil {
 				return err
 			}
 
-			currentVersion, currentVersionSource, err := envoy.CurrentVersion(o.HomeDir)
+			currentVersion, currentVersionSource, err := envoy.CurrentVersion(o.DataHome, o.EnvoyVersionFile(), o.EnvoyVersionFileSource())
 			if err != nil {
 				return err
 			}
@@ -79,9 +78,9 @@ type versionReleaseDate struct {
 	releaseDate version.ReleaseDate
 }
 
-func getInstalledVersions(homeDir string) ([]versionReleaseDate, error) {
+func getInstalledVersions(versionsDir string) ([]versionReleaseDate, error) {
 	var rows []versionReleaseDate
-	files, err := os.ReadDir(filepath.Join(homeDir, "versions"))
+	files, err := os.ReadDir(versionsDir)
 	if os.IsNotExist(err) {
 		return rows, nil
 	} else if err != nil {

--- a/internal/cmd/versions_test.go
+++ b/internal/cmd/versions_test.go
@@ -20,34 +20,35 @@ func TestGetInstalledVersions_ErrorsWhenFileIsInVersionsDir(t *testing.T) {
 	versionsDir := filepath.Join(homeDir, "versions")
 	require.NoError(t, os.WriteFile(versionsDir, []byte{}, 0o600))
 
-	_, err := getInstalledVersions(homeDir)
+	_, err := getInstalledVersions(versionsDir)
 	require.Error(t, err)
 }
 
 func TestGetInstalledVersions_MissingOrEmptyVersionsDir(t *testing.T) {
 	homeDir := t.TempDir()
+	versionsDir := filepath.Join(homeDir, "versions")
 
-	rows, err := getInstalledVersions(homeDir)
+	rows, err := getInstalledVersions(versionsDir)
 	require.NoError(t, err) // ensures we don't error just because nothing is installed yet.
 	require.Empty(t, rows)
 
 	// Now, create the versions directory but don't add one
-	versionsDir := filepath.Join(homeDir, "versions")
 	require.NoError(t, os.Mkdir(versionsDir, 0o700))
 
-	rows, err = getInstalledVersions(homeDir)
+	rows, err = getInstalledVersions(versionsDir)
 	require.NoError(t, err)
 	require.Empty(t, rows)
 }
 
 func TestGetInstalledVersions_ReleaseDateFromMtime(t *testing.T) {
 	homeDir := t.TempDir()
+	versionsDir := filepath.Join(homeDir, "versions")
 
-	oneOneTwo := filepath.Join(homeDir, "versions", "1.1.2")
+	oneOneTwo := filepath.Join(versionsDir, "1.1.2")
 	require.NoError(t, os.MkdirAll(oneOneTwo, 0o700))
 	morerequire.RequireSetMtime(t, oneOneTwo, "2020-12-31")
 
-	rows, err := getInstalledVersions(homeDir)
+	rows, err := getInstalledVersions(versionsDir)
 	require.NoError(t, err)
 	require.Equal(t, []versionReleaseDate{{"1.1.2", "2020-12-31"}}, rows)
 }
@@ -65,7 +66,7 @@ func TestGetInstalledVersions_SkipsFileInVersionsDir(t *testing.T) {
 	morerequire.RequireSetMtime(t, oneOneTwo, "2020-12-31")
 
 	// ensure there are no versions in the output
-	rows, err := getInstalledVersions(homeDir)
+	rows, err := getInstalledVersions(versionsDir)
 	require.NoError(t, err)
 	require.Empty(t, rows)
 }

--- a/internal/cmd/which_test.go
+++ b/internal/cmd/which_test.go
@@ -18,7 +18,7 @@ func TestFuncEWhich(t *testing.T) {
 	c, stdout, stderr := newApp(o)
 
 	require.NoError(t, c.Run([]string{"func-e", "which"}))
-	envoyPath := filepath.Join(o.HomeDir, "versions", o.EnvoyVersion.String(), "bin", "envoy")
+	envoyPath := filepath.Join(o.DataHome, "envoy-versions", o.EnvoyVersion.String(), "bin", "envoy")
 	require.Equal(t, fmt.Sprintf("%s\n", envoyPath), stdout.String())
 	require.Empty(t, stderr)
 }

--- a/internal/envoy/install.go
+++ b/internal/envoy/install.go
@@ -22,7 +22,7 @@ var binEnvoy = filepath.Join("bin", "envoy")
 // InstallIfNeeded downloads an Envoy binary corresponding to globals.GlobalOpts and returns a path to it or an error.
 func InstallIfNeeded(ctx context.Context, o *globals.GlobalOpts) (string, error) {
 	v := o.EnvoyVersion
-	installPath := filepath.Join(o.HomeDir, "versions", v.String())
+	installPath := filepath.Join(o.EnvoyVersionsDir(), v.String())
 	envoyPath := filepath.Join(installPath, binEnvoy)
 	_, err := os.Stat(envoyPath)
 	switch {

--- a/internal/envoy/install_test.go
+++ b/internal/envoy/install_test.go
@@ -237,12 +237,15 @@ func setupInstallTest(t *testing.T) *installTest {
 		tempDir:    t.TempDir(),
 		tarballURL: test.TarballURL(versionsServer.URL, runtime.GOOS, runtime.GOARCH, version.LastKnownEnvoy),
 		GlobalOpts: globals.GlobalOpts{
-			HomeDir:          homeDir,
+			ConfigHome:       homeDir,
+			DataHome:         homeDir,
+			StateHome:        homeDir,
+			RuntimeDir:       homeDir,
 			EnvoyVersionsURL: versionsServer.URL + "/envoy-versions.json",
 			Out:              new(bytes.Buffer),
 			Platform:         globals.DefaultPlatform,
 			RunOpts: globals.RunOpts{
-				EnvoyPath: filepath.Join(homeDir, "versions", version.LastKnownEnvoy.String(), binEnvoy),
+				EnvoyPath: filepath.Join(homeDir, "envoy-versions", version.LastKnownEnvoy.String(), binEnvoy),
 			},
 		},
 	}

--- a/internal/globals/paths.go
+++ b/internal/globals/paths.go
@@ -1,0 +1,75 @@
+// Copyright 2025 Tetrate
+// SPDX-License-Identifier: Apache-2.0
+
+package globals
+
+import (
+	"fmt"
+	"path/filepath"
+	"strconv"
+	"time"
+)
+
+// EnvoyVersionsDir returns the directory containing Envoy binaries.
+// Legacy: "$dataHome/versions"
+// Default: "$dataHome/envoy-versions"
+func (o *GlobalOpts) EnvoyVersionsDir() string {
+	if o.HomeDir != "" {
+		return filepath.Join(o.DataHome, "versions")
+	}
+	return filepath.Join(o.DataHome, "envoy-versions")
+}
+
+// EnvoyVersionFile returns the path to the selected version file.
+// Legacy: "$homeDir/version"
+// Default: "$configHome/envoy-version"
+func (o *GlobalOpts) EnvoyVersionFile() string {
+	if o.HomeDir != "" {
+		return filepath.Join(o.DataHome, "version")
+	}
+	return filepath.Join(o.ConfigHome, "envoy-version")
+}
+
+// EnvoyVersionFileSource returns the display string for the version file source.
+// This is used in help text and command output.
+// Legacy: "$FUNC_E_HOME/version"
+// Default: "$FUNC_E_CONFIG_HOME/envoy-version"
+func (o *GlobalOpts) EnvoyVersionFileSource() string {
+	if o.HomeDir != "" {
+		return "$FUNC_E_HOME/version"
+	}
+	return "$FUNC_E_CONFIG_HOME/envoy-version"
+}
+
+// EnvoyRunDir returns the directory for a specific run (logs, config_dump.json, etc.).
+// Legacy: "$stateHome/runs/{runID}"
+// Default: "$stateHome/envoy-runs/{runID}"
+func (o *GlobalOpts) EnvoyRunDir(runID string) string {
+	if o.HomeDir != "" {
+		return filepath.Join(o.StateHome, "runs", runID)
+	}
+	return filepath.Join(o.StateHome, "envoy-runs", runID)
+}
+
+// EnvoyRuntimeDir returns the directory for temporary files of a specific run.
+// Legacy: "$runtimeDir/runs/{runID}"
+// Default: "$runtimeDir/{runID}"
+func (o *GlobalOpts) EnvoyRuntimeDir(runID string) string {
+	if o.HomeDir != "" {
+		return filepath.Join(o.RuntimeDir, "runs", runID)
+	}
+	return filepath.Join(o.RuntimeDir, runID)
+}
+
+// GenerateRunID creates a unique run identifier.
+// Legacy: epoch nanoseconds "1760229853109700000"
+// Default: "20251012_143053_700" (YYYYMMDD_HHMMSS_UUU)
+func (o *GlobalOpts) GenerateRunID(t time.Time) string {
+	if o.HomeDir != "" {
+		return strconv.FormatInt(t.UnixNano(), 10)
+	}
+	// YYYYMMDD_HHMMSS_UUU format
+	// Last 3 digits of microseconds to allow concurrent runs
+	micro := t.Nanosecond() / 1000 % 1000
+	return fmt.Sprintf("%s_%03d", t.Format("20060102_150405"), micro)
+}

--- a/internal/globals/paths_test.go
+++ b/internal/globals/paths_test.go
@@ -1,0 +1,215 @@
+// Copyright func-e contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package globals
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestEnvoyVersionsDir(t *testing.T) {
+	tests := []struct {
+		name     string
+		dataHome string
+		homeDir  string
+		expected string
+	}{
+		{
+			name:     "separate directories",
+			dataHome: "/home/user/.local/share/func-e",
+			homeDir:  "",
+			expected: "/home/user/.local/share/func-e/envoy-versions",
+		},
+		{
+			name:     "legacy mode",
+			dataHome: "/home/user/func-e",
+			homeDir:  "/home/user/func-e",
+			expected: "/home/user/func-e/versions",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			o := &GlobalOpts{
+				DataHome: tc.dataHome,
+				HomeDir:  tc.homeDir,
+			}
+			actual := o.EnvoyVersionsDir()
+			require.Equal(t, tc.expected, actual)
+		})
+	}
+}
+
+func TestEnvoyVersionFile(t *testing.T) {
+	tests := []struct {
+		name       string
+		configHome string
+		dataHome   string
+		homeDir    string
+		expected   string
+	}{
+		{
+			name:       "separate directories",
+			configHome: "/home/user/.config/func-e",
+			dataHome:   "/home/user/.local/share/func-e",
+			homeDir:    "",
+			expected:   "/home/user/.config/func-e/envoy-version",
+		},
+		{
+			name:       "legacy mode",
+			configHome: "/home/user/func-e",
+			dataHome:   "/home/user/func-e",
+			homeDir:    "/home/user/func-e",
+			expected:   "/home/user/func-e/version",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			o := &GlobalOpts{
+				ConfigHome: tc.configHome,
+				DataHome:   tc.dataHome,
+				HomeDir:    tc.homeDir,
+			}
+			actual := o.EnvoyVersionFile()
+			require.Equal(t, tc.expected, actual)
+		})
+	}
+}
+
+func TestEnvoyRunDir(t *testing.T) {
+	tests := []struct {
+		name      string
+		stateHome string
+		homeDir   string
+		runID     string
+		expected  string
+	}{
+		{
+			name:      "separate directories",
+			stateHome: "/home/user/.local/state/func-e",
+			homeDir:   "",
+			runID:     "2025-01-15T12:34:56",
+			expected:  "/home/user/.local/state/func-e/envoy-runs/2025-01-15T12:34:56",
+		},
+		{
+			name:      "legacy mode",
+			stateHome: "/home/user/func-e",
+			homeDir:   "/home/user/func-e",
+			runID:     "1619574747231823000",
+			expected:  "/home/user/func-e/runs/1619574747231823000",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			o := &GlobalOpts{
+				StateHome: tc.stateHome,
+				HomeDir:   tc.homeDir,
+			}
+			actual := o.EnvoyRunDir(tc.runID)
+			require.Equal(t, tc.expected, actual)
+		})
+	}
+}
+
+func TestEnvoyRuntimeDir(t *testing.T) {
+	tests := []struct {
+		name       string
+		runtimeDir string
+		homeDir    string
+		runID      string
+		expected   string
+	}{
+		{
+			name:       "separate directories",
+			runtimeDir: "/tmp/func-e-1000",
+			homeDir:    "",
+			runID:      "20250115_123456_000",
+			expected:   filepath.Join("/tmp/func-e-1000", "20250115_123456_000"),
+		},
+		{
+			name:       "legacy mode",
+			runtimeDir: "/home/user/func-e",
+			homeDir:    "/home/user/func-e",
+			runID:      "1619574747231823000",
+			expected:   filepath.Join("/home/user/func-e/runs", "1619574747231823000"),
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			o := &GlobalOpts{
+				RuntimeDir: tc.runtimeDir,
+				HomeDir:    tc.homeDir,
+			}
+			actual := o.EnvoyRuntimeDir(tc.runID)
+			require.Equal(t, tc.expected, actual)
+		})
+	}
+}
+
+func TestGenerateRunID(t *testing.T) {
+	tests := []struct {
+		name            string
+		homeDir         string
+		now             time.Time
+		expectedPattern string
+	}{
+		{
+			name:            "timestamp format",
+			homeDir:         "",
+			now:             time.Date(2025, 1, 15, 12, 34, 56, 789000000, time.UTC),
+			expectedPattern: "20250115_123456_000",
+		},
+		{
+			name:            "legacy mode - epoch nanoseconds",
+			homeDir:         "/home/user/func-e",
+			now:             time.Date(2021, 4, 27, 18, 39, 7, 231823000, time.UTC),
+			expectedPattern: "1619548747231823000",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			o := &GlobalOpts{
+				HomeDir: tc.homeDir,
+			}
+			actual := o.GenerateRunID(tc.now)
+			require.Equal(t, tc.expectedPattern, actual)
+		})
+	}
+}
+
+func TestEnvoyVersionFileSource(t *testing.T) {
+	tests := []struct {
+		name     string
+		homeDir  string
+		expected string
+	}{
+		{
+			name:     "separate directories",
+			homeDir:  "",
+			expected: "$FUNC_E_CONFIG_HOME/envoy-version",
+		},
+		{
+			name:     "legacy mode",
+			homeDir:  "/home/user/func-e",
+			expected: "$FUNC_E_HOME/version",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			o := &GlobalOpts{
+				HomeDir: tc.homeDir,
+			}
+			actual := o.EnvoyVersionFileSource()
+			require.Equal(t, tc.expected, actual)
+		})
+	}
+}

--- a/internal/run/func-e_run_test.go
+++ b/internal/run/func-e_run_test.go
@@ -21,8 +21,12 @@ func TestRun_LogWarn(t *testing.T) {
 	e2e.TestRun_LogWarn(t.Context(), t, fakeFuncEFactory{})
 }
 
-func TestRun_RunDirectory(t *testing.T) {
-	e2e.TestRun_RunDirectory(t.Context(), t, fakeFuncEFactory{})
+func TestRun_RunDir(t *testing.T) {
+	// Test that FUNC_E_STATE_HOME env var works correctly to control
+	// where runtime-generated files (logs, config_dump.json) are written.
+	stateDir := t.TempDir()
+	t.Setenv("FUNC_E_STATE_HOME", stateDir)
+	e2e.TestRun_RunDir(t.Context(), t, fakeFuncEFactory{}, stateDir)
 }
 
 func TestRun_InvalidConfig(t *testing.T) {
@@ -36,4 +40,10 @@ func TestRun_StaticFile(t *testing.T) {
 func TestRun_CtrlCs(t *testing.T) {
 	// This doesn't call ctrl-c, rather cancels the context multiple times
 	e2e.TestRun_CtrlCs(t.Context(), t, fakeFuncEFactory{})
+}
+
+func TestRun_LegacyHomeDir(t *testing.T) {
+	homeDir := t.TempDir()
+	t.Setenv("FUNC_E_HOME", homeDir)
+	e2e.TestRun_LegacyHomeDir(t.Context(), t, fakeFuncEFactory{})
 }

--- a/internal/run/func-e_test.go
+++ b/internal/run/func-e_test.go
@@ -11,32 +11,76 @@ import (
 	"time"
 
 	"github.com/tetratelabs/func-e/api"
-	"github.com/tetratelabs/func-e/experimental/admin"
+	internaladmin "github.com/tetratelabs/func-e/internal/admin"
 	internalapi "github.com/tetratelabs/func-e/internal/api"
 	"github.com/tetratelabs/func-e/internal/globals"
 	"github.com/tetratelabs/func-e/internal/runtime"
 	"github.com/tetratelabs/func-e/internal/test/e2e"
 )
 
-// fakeFuncEFactory implements runtest.FuncEFactory for API tests using fake envoy
+// fakeFuncEFactory implements e2e.FuncEFactory for API tests using fake envoy
 type fakeFuncEFactory struct{}
 
-func (fakeFuncEFactory) New(ctx context.Context, t *testing.T, stdout, stderr io.Writer) (e2e.FuncE, error) {
-	o, err := initOpts(ctx, api.HomeDir(t.TempDir()),
+func (f fakeFuncEFactory) New(ctx context.Context, t *testing.T, stdout, stderr io.Writer) (e2e.FuncE, error) {
+	var opts []api.RunOption
+
+	// Read from environment variables to support both legacy and separate directory modes
+	// This mirrors CLI behavior where env vars control directory structure
+	homeDir := os.Getenv("FUNC_E_HOME")
+	dataHome := os.Getenv("FUNC_E_DATA_HOME")
+	stateHome := os.Getenv("FUNC_E_STATE_HOME")
+	runtimeDir := os.Getenv("FUNC_E_RUNTIME_DIR")
+
+	switch {
+	case homeDir != "":
+		// Legacy mode via FUNC_E_HOME
+		opts = []api.RunOption{api.HomeDir(homeDir)} //nolint:staticcheck // intentional use of deprecated API for legacy mode testing
+	case dataHome != "" || stateHome != "" || runtimeDir != "":
+		// Separate directories mode - apply only what's set via env vars
+		// Helper function to get directory or create temp dir
+		getDir := func(envValue string) string {
+			if envValue != "" {
+				return envValue
+			}
+			return t.TempDir()
+		}
+
+		opts = append(opts,
+			api.DataHome(getDir(dataHome)),
+			api.StateHome(getDir(stateHome)),
+			api.RuntimeDir(getDir(runtimeDir)))
+	default:
+		// Default: use separate temp directories
+		opts = []api.RunOption{
+			api.DataHome(t.TempDir()),
+			api.StateHome(t.TempDir()),
+			api.RuntimeDir(t.TempDir()),
+		}
+	}
+
+	opts = append(opts,
 		EnvoyPath(fakeEnvoyBin),
 		api.Out(stdout),
 		api.EnvoyOut(stdout),
 		api.EnvoyErr(stderr))
+
+	o, err := initOpts(ctx, opts...)
 	if err != nil {
 		return nil, err
 	}
 	return &fakeFuncE{o: o}, nil
 }
 
-// fakeFuncE implements runtest.FuncE for API tests using fake envoy
+// fakeFuncE implements e2e.FuncE for API tests using fake envoy
 type fakeFuncE struct {
 	o          *globals.GlobalOpts
 	cancelFunc context.CancelFunc
+	envoyPid   int
+}
+
+// EnvoyPid implements the same method as documented on e2e.FuncE
+func (f *fakeFuncE) EnvoyPid() int {
+	return f.envoyPid
 }
 
 // Interrupt cancels the context created in Run as we don't want to actually interrupt the calling test!
@@ -50,7 +94,13 @@ func (f *fakeFuncE) Interrupt(context.Context) error {
 
 // OnStart creates an admin client using the run directory and waits for Envoy to be ready.
 func (f *fakeFuncE) OnStart(ctx context.Context) (internalapi.AdminClient, error) {
-	adminClient, err := admin.NewAdminClient(ctx, os.Getpid())
+	// Poll for the admin address path from the Envoy process command line
+	envoyPid, adminAddressPath, err := internaladmin.PollEnvoyPidAndAdminAddressPath(ctx, os.Getpid())
+	if err != nil {
+		return nil, err
+	}
+	f.envoyPid = envoyPid
+	adminClient, err := internaladmin.NewAdminClient(ctx, adminAddressPath)
 	if err == nil {
 		err = adminClient.AwaitReady(ctx, 100*time.Millisecond)
 	}

--- a/internal/run/run.go
+++ b/internal/run/run.go
@@ -57,6 +57,10 @@ func initOpts(ctx context.Context, options ...api.RunOption) (*globals.GlobalOpt
 	o := &globals.GlobalOpts{
 		EnvoyVersion: version.PatchVersion(ro.EnvoyVersion),
 		Out:          ro.Out,
+		ConfigHome:   ro.ConfigHome,
+		DataHome:     ro.DataHome,
+		StateHome:    ro.StateHome,
+		RuntimeDir:   ro.RuntimeDir,
 		RunOpts: globals.RunOpts{
 			EnvoyPath:   ro.EnvoyPath,
 			EnvoyOut:    ro.EnvoyOut,
@@ -64,7 +68,13 @@ func initOpts(ctx context.Context, options ...api.RunOption) (*globals.GlobalOpt
 			StartupHook: ro.StartupHook,
 		},
 	}
-	if err := runtime.InitializeGlobalOpts(o, ro.EnvoyVersionsURL, ro.HomeDir, ""); err != nil {
+	// Note: api.HomeDir() sets ConfigHome, DataHome, StateHome, RuntimeDir to same value (legacy mode)
+	// Legacy detection happens in InitializeGlobalOpts when all four match
+	homeDir := ""
+	if ro.ConfigHome != "" && ro.ConfigHome == ro.DataHome && ro.DataHome == ro.StateHome && ro.StateHome == ro.RuntimeDir {
+		homeDir = ro.ConfigHome // Legacy mode
+	}
+	if err := runtime.InitializeGlobalOpts(o, ro.EnvoyVersionsURL, homeDir, ro.ConfigHome, ro.DataHome, ro.StateHome, ro.RuntimeDir, "", ro.RunID); err != nil {
 		return nil, err
 	}
 

--- a/internal/runtime/opts_test.go
+++ b/internal/runtime/opts_test.go
@@ -20,7 +20,10 @@ func TestInitializeGlobalOpts(t *testing.T) {
 	require.NoError(t, err)
 
 	alt1 := filepath.Join(u.HomeDir, "alt1")
-	defaultHome := filepath.Join(u.HomeDir, ".func-e")
+	defaultConfigHome := filepath.Join(u.HomeDir, ".config/func-e")
+	defaultDataHome := filepath.Join(u.HomeDir, ".local/share/func-e")
+	defaultStateHome := filepath.Join(u.HomeDir, ".local/state/func-e")
+	defaultRuntimeDir := "/tmp/func-e-" + u.Uid
 	defaultPlatform := globals.DefaultPlatform
 	defaultVersionsURL := globals.DefaultEnvoyVersionsURL
 
@@ -28,7 +31,12 @@ func TestInitializeGlobalOpts(t *testing.T) {
 		name             string
 		envoyVersionsURL string
 		homeDir          string
+		configHome       string
+		dataHome         string
+		stateHome        string
+		runtimeDir       string
 		platform         string
+		runID            string
 		expected         globals.GlobalOpts
 		expectedErr      string
 	}{
@@ -38,30 +46,78 @@ func TestInitializeGlobalOpts(t *testing.T) {
 			expectedErr:      `"/not/url" is not a valid Envoy versions URL`,
 		},
 		{
-			name:     "default is ~/.func-e",
-			expected: globals.GlobalOpts{HomeDir: defaultHome, Platform: defaultPlatform, EnvoyVersionsURL: defaultVersionsURL},
+			name:     "default directories",
+			expected: globals.GlobalOpts{ConfigHome: defaultConfigHome, DataHome: defaultDataHome, StateHome: defaultStateHome, RuntimeDir: defaultRuntimeDir, Platform: defaultPlatform, EnvoyVersionsURL: defaultVersionsURL},
 		},
 		{
-			name:     "--home-dir arg",
+			name:     "--home-dir arg (legacy mode)",
 			homeDir:  alt1,
-			expected: globals.GlobalOpts{HomeDir: alt1, Platform: defaultPlatform, EnvoyVersionsURL: defaultVersionsURL},
+			expected: globals.GlobalOpts{ConfigHome: alt1, DataHome: alt1, StateHome: alt1, RuntimeDir: alt1, Platform: defaultPlatform, EnvoyVersionsURL: defaultVersionsURL},
 		},
 		{
 			name:     "--platform flag",
 			platform: "darwin/amd64",
-			expected: globals.GlobalOpts{HomeDir: defaultHome, Platform: version.Platform("darwin/amd64"), EnvoyVersionsURL: defaultVersionsURL},
+			expected: globals.GlobalOpts{ConfigHome: defaultConfigHome, DataHome: defaultDataHome, StateHome: defaultStateHome, RuntimeDir: defaultRuntimeDir, Platform: version.Platform("darwin/amd64"), EnvoyVersionsURL: defaultVersionsURL},
 		},
 		{
 			name:             "--envoy-versions-url flag",
 			envoyVersionsURL: "http://versions/arg",
-			expected:         globals.GlobalOpts{HomeDir: defaultHome, Platform: defaultPlatform, EnvoyVersionsURL: "http://versions/arg"},
+			expected:         globals.GlobalOpts{ConfigHome: defaultConfigHome, DataHome: defaultDataHome, StateHome: defaultStateHome, RuntimeDir: defaultRuntimeDir, Platform: defaultPlatform, EnvoyVersionsURL: "http://versions/arg"},
+		},
+		{
+			name:       "--config-home only",
+			configHome: alt1,
+			expected:   globals.GlobalOpts{ConfigHome: alt1, DataHome: defaultDataHome, StateHome: defaultStateHome, RuntimeDir: defaultRuntimeDir, Platform: defaultPlatform, EnvoyVersionsURL: defaultVersionsURL},
+		},
+		{
+			name:     "--data-home only",
+			dataHome: alt1,
+			expected: globals.GlobalOpts{ConfigHome: defaultConfigHome, DataHome: alt1, StateHome: defaultStateHome, RuntimeDir: defaultRuntimeDir, Platform: defaultPlatform, EnvoyVersionsURL: defaultVersionsURL},
+		},
+		{
+			name:      "--state-home only",
+			stateHome: alt1,
+			expected:  globals.GlobalOpts{ConfigHome: defaultConfigHome, DataHome: defaultDataHome, StateHome: alt1, RuntimeDir: defaultRuntimeDir, Platform: defaultPlatform, EnvoyVersionsURL: defaultVersionsURL},
+		},
+		{
+			name:       "--runtime-dir only",
+			runtimeDir: alt1,
+			expected:   globals.GlobalOpts{ConfigHome: defaultConfigHome, DataHome: defaultDataHome, StateHome: defaultStateHome, RuntimeDir: alt1, Platform: defaultPlatform, EnvoyVersionsURL: defaultVersionsURL},
+		},
+		{
+			name:       "all directories specified",
+			configHome: filepath.Join(u.HomeDir, "config"),
+			dataHome:   filepath.Join(u.HomeDir, "data"),
+			stateHome:  filepath.Join(u.HomeDir, "state"),
+			runtimeDir: filepath.Join(u.HomeDir, "runtime"),
+			expected:   globals.GlobalOpts{ConfigHome: filepath.Join(u.HomeDir, "config"), DataHome: filepath.Join(u.HomeDir, "data"), StateHome: filepath.Join(u.HomeDir, "state"), RuntimeDir: filepath.Join(u.HomeDir, "runtime"), Platform: defaultPlatform, EnvoyVersionsURL: defaultVersionsURL},
+		},
+		{
+			name:     "custom runID",
+			runID:    "my-custom-run",
+			expected: globals.GlobalOpts{ConfigHome: defaultConfigHome, DataHome: defaultDataHome, StateHome: defaultStateHome, RuntimeDir: defaultRuntimeDir, Platform: defaultPlatform, EnvoyVersionsURL: defaultVersionsURL},
+		},
+		{
+			name:     "custom runID numeric (Docker use case)",
+			runID:    "0",
+			expected: globals.GlobalOpts{ConfigHome: defaultConfigHome, DataHome: defaultDataHome, StateHome: defaultStateHome, RuntimeDir: defaultRuntimeDir, Platform: defaultPlatform, EnvoyVersionsURL: defaultVersionsURL},
+		},
+		{
+			name:        "custom runID with forward slash rejected",
+			runID:       "invalid/path",
+			expectedErr: `runID cannot contain path separators (/ or \): "invalid/path"`,
+		},
+		{
+			name:        "custom runID with backslash rejected",
+			runID:       `invalid\path`,
+			expectedErr: `runID cannot contain path separators (/ or \): "invalid\\path"`,
 		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			o := &globals.GlobalOpts{}
-			err := runtime.InitializeGlobalOpts(o, tc.envoyVersionsURL, tc.homeDir, tc.platform)
+			err := runtime.InitializeGlobalOpts(o, tc.envoyVersionsURL, tc.homeDir, tc.configHome, tc.dataHome, tc.stateHome, tc.runtimeDir, tc.platform, tc.runID)
 
 			if tc.expectedErr != "" {
 				require.EqualError(t, err, tc.expectedErr)
@@ -70,9 +126,18 @@ func TestInitializeGlobalOpts(t *testing.T) {
 
 			require.NoError(t, err)
 
-			require.Equal(t, tc.expected.HomeDir, o.HomeDir)
+			require.Equal(t, tc.expected.ConfigHome, o.ConfigHome)
+			require.Equal(t, tc.expected.DataHome, o.DataHome)
+			require.Equal(t, tc.expected.StateHome, o.StateHome)
+			require.Equal(t, tc.expected.RuntimeDir, o.RuntimeDir)
 			require.Equal(t, tc.expected.Platform, o.Platform)
 			require.Equal(t, tc.expected.EnvoyVersionsURL, o.EnvoyVersionsURL)
+
+			if tc.runID != "" {
+				require.Equal(t, tc.runID, o.RunID, "Custom RunID should be used")
+			} else {
+				require.NotEmpty(t, o.RunID, "RunID should be auto-generated when empty")
+			}
 		})
 	}
 }

--- a/internal/test/e2e/func-e.go
+++ b/internal/test/e2e/func-e.go
@@ -22,6 +22,9 @@ type FuncE interface {
 	// The returned error might be a process exit or context cancellation.
 	Run(ctx context.Context, args []string) error
 
+	// EnvoyPid is non-zero when the process launched.
+	EnvoyPid() int
+
 	// Interrupt signals the running func-e process to terminate gracefully
 	Interrupt(context.Context) error
 

--- a/internal/testdata/fake_envoy/main.go
+++ b/internal/testdata/fake_envoy/main.go
@@ -337,7 +337,7 @@ func adminEndpoints(w http.ResponseWriter, r *http.Request) {
 func accessLogHandler(w http.ResponseWriter, r *http.Request) {
 	startTime := time.Now()
 
-	// The corresponding config returns a constant response so we know what the
+	// The corresponding config returns a constant response, so we know what the
 	// status code will be.
 	response := []byte("Hello, World!")
 	w.WriteHeader(http.StatusOK)

--- a/packaging/nfpm/func-e.8
+++ b/packaging/nfpm/func-e.8
@@ -9,9 +9,14 @@ func-e \- Install and run Envoy
 func-e
 
 .EX
+[--config-home]=[value]
+[--data-home]=[value]
 [--envoy-versions-url]=[value]
 [--home-dir]=[value]
 [--platform]=[value]
+[--run-id]=[value]
+[--runtime-dir]=[value]
+[--state-home]=[value]
 .EE
 
 .PP
@@ -23,29 +28,54 @@ downloads and installs the latest version of Envoy for you.
 
 To list versions of Envoy you can use, execute `func-e versions -a`. To
 choose one, invoke `func-e use 1.35.3`. This installs into
-`$FUNC_E_HOME/versions/1.35.3`, if not already present. You may also use
-minor version, such as `func-e use 1.35`.
+`$FUNC_E_DATA_HOME/envoy-versions/1.35.3`, if not already present. You may
+also use minor version, such as `func-e use 1.35`.
 
 You may want to override `$ENVOY_VERSIONS_URL` to supply custom builds or
 otherwise control the source of Envoy binaries. When overriding, validate
 your JSON first: https://archive.tetratelabs.io/release-versions-schema.json
 
+Directory structure:
+  `$FUNC_E_CONFIG_HOME` stores configuration files
+    (default: ${HOME}/.config/func-e)
+  `$FUNC_E_DATA_HOME` stores Envoy binaries
+    (default: ${HOME}/.local/share/func-e)
+  `$FUNC_E_STATE_HOME` stores logs
+    (default: ${HOME}/.local/state/func-e)
+  `$FUNC_E_RUNTIME_DIR` stores temporary files
+    (default: /tmp/func-e-${UID})
+
 Advanced:
 `FUNC_E_PLATFORM` overrides the host OS and architecture of Envoy binaries.
 This is used when emulating another platform, e.g. x86 on Apple Silicon M1.
 Note: Changing the OS value can cause problems as Envoy has dependencies,
-such as glibc. This value must be constant within a `$FUNC_E_HOME`.
+such as glibc. This value must be constant within a `$FUNC_E_DATA_HOME`.
 .EE
 
 
 .SH GLOBAL OPTIONS
+\fB--config-home\fP="": directory for configuration files (default: ${HOME}/.config/func-e)
+
+.PP
+\fB--data-home\fP="": directory for Envoy binaries (default: ${HOME}/.local/share/func-e)
+
+.PP
 \fB--envoy-versions-url\fP="": URL of Envoy versions JSON (default: https://archive.tetratelabs.io/envoy/envoy-versions.json)
 
 .PP
-\fB--home-dir\fP="": func-e home directory (location of installed versions and run archives) (default: ${HOME}/.func-e)
+\fB--home-dir\fP="": (deprecated) func-e home directory - use --config-home, --data-home, --state-home or --runtime-dir instead
 
 .PP
 \fB--platform\fP="": the host OS and architecture of Envoy binaries. Ex. darwin/arm64 (default: $GOOS/$GOARCH)
+
+.PP
+\fB--run-id\fP="": custom run identifier for logs/runtime directories (used by run command) (default: auto-generated timestamp)
+
+.PP
+\fB--runtime-dir\fP="": directory for temporary files (used by run command) (default: /tmp/func-e-${UID})
+
+.PP
+\fB--state-home\fP="": directory for logs (used by run command) (default: ${HOME}/.local/state/func-e)
 
 
 .SH COMMANDS

--- a/run_test.go
+++ b/run_test.go
@@ -23,7 +23,7 @@ import (
 // but still give some coverage.
 func TestFuncERun_InvalidConfig(t *testing.T) {
 	var stdout, stderr bytes.Buffer
-	err := func_e.Run(t.Context(), []string{}, api.HomeDir(t.TempDir()), run.EnvoyPath(fakeEnvoyBin),
+	err := func_e.Run(t.Context(), []string{}, api.HomeDir(t.TempDir()), run.EnvoyPath(fakeEnvoyBin), //nolint:staticcheck // intentional use of deprecated API for legacy mode testing
 		api.Out(&stdout),
 		api.EnvoyOut(&stdout),
 		api.EnvoyErr(&stderr))


### PR DESCRIPTION
This refactors func-e to use config_home, data_home, state_home and runtime_dir conventions defined in [XDG](https://specifications.freedesktop.org/basedir-spec/latest/).

Instead of the now deprecated `api.HomeDir()`/`$FUNC_E_HOME`, we have four tiers:
- `api.ConfigHome()`/`$FUNC_E_CONFIG_HOME`: Configuration files like version preferences (default: ~/.config/func-e)
- `api.DataHome()`/`$FUNC_E_DATA_HOME`: Envoy binaries and downloaded data (default: ~/.local/share/func-e)
- `api.StateHome()`/`$FUNC_E_STATE_HOME`: Run logs and persistent state (default: ~/.local/state/func-e)
- `api.RuntimeDir()`/`$FUNC_E_RUNTIME_DIR`: Ephemeral temporary files (default: /tmp/func-e-${UID})

This separation aligns with XDG Base Directory Specification principles:
- **Configuration** (envoy-version) is distinct from **data** (binaries)
- **State** (logs) is separate from ephemeral **temporary** files (admin addresses)
- Each directory can be independently configured for different storage tiers
- Docker deployments can easily map volumes to appropriate directories

**Run ID**

This also adds `api.RunID()`/`$FUNC_E_RUN_ID` to override the formerly epoch timestamp with something else for predictable paths in Docker which only support one run typically. For example, we can set it to zero and always know where the logs are.

Here are details on the implementation:
- --run-id: Sets custom run identifier for current execution (or $FUNC_E_RUN_ID)
- Default: YYYYMMDD_HHMMSS_UUU (human-readable timestamp)
- Previous: epoch nanoseconds (less readable)
- Enables predictable paths for docker (e.g. setting to zero)

**Migration**

func-e begins immediately to use these conventions except in cases where the deprecated $FUNC_E_HOME was overridden, such as envoyproxy/gateway. This allows tools to migrate on their own schedule.

Unless you set the now deprecated `api.HomeDir()`/`$FUNC_E_HOME`, files end up in the new layout described above:
- Version preference: $FUNC_E_CONFIG_HOME/envoy-version (was: $FUNC_E_HOME/version)
- Binaries: $FUNC_E_DATA_HOME/envoy-versions/{version}/bin/envoy (was: $FUNC_E_HOME/versions/{version}/bin/envoy)
- Run logs: $FUNC_E_STATE_HOME/envoy-runs/{runID}/stdout.log (was: $FUNC_E_HOME/runs/{epoch}/stdout.log)
- Admin address: $FUNC_E_RUNTIME_DIR/{runID}/admin-address.txt (was: $FUNC_E_HOME/runs/{epoch}/admin-address.txt)
