### PR TITLE
Integrates `RunID` and `HTTPTransport` to `NewAdminClient`

### DIFF
--- a/e2e/func-e_test.go
+++ b/e2e/func-e_test.go
@@ -104,7 +104,7 @@ func (a *funcE) OnStart(ctx context.Context) (admin.AdminClient, error) {
 	funcEPid := a.cmd.Process.Pid
 
 	// Poll for the admin address path from the Envoy process command line
-	envoyPid, adminAddressPath, err := internaladmin.PollEnvoyPidAndAdminAddressPath(ctx, funcEPid)
+	envoyPid, adminAddressPath, err := internaladmin.PollEnvoyPidAndAdminAddressPath(ctx, funcEPid, "")
 	if err != nil {
 		return nil, err
 	}

--- a/experimental/admin/admin.go
+++ b/experimental/admin/admin.go
@@ -18,13 +18,26 @@ import (
 type AdminClient = internalapi.AdminClient
 
 // NewAdminClient returns an AdminClient if `funcEPid` has a child envoy process.
-func NewAdminClient(ctx context.Context, funcEPid int) (AdminClient, error) {
-	// Poll for the admin address path from the Envoy process command line
-	_, adminAddressPath, err := admin.PollEnvoyPidAndAdminAddressPath(ctx, funcEPid)
+//
+// Supported api.RunOption values:
+// - api.RunID - use when funcEPid launched multiple envoys
+// - api.HTTPTransport - use in testing or observability.
+func NewAdminClient(ctx context.Context, funcEPid int, options ...api.RunOption) (AdminClient, error) {
+	var opts internalapi.RunOpts
+	for _, o := range options {
+		o(&opts)
+	}
+
+	_, adminAddressPath, err := admin.PollEnvoyPidAndAdminAddressPath(ctx, funcEPid, opts.RunID)
 	if err != nil {
 		return nil, err
 	}
-	return admin.NewAdminClient(ctx, http.DefaultClient, adminAddressPath)
+
+	transport := opts.HTTPTransport
+	if transport == nil {
+		transport = http.DefaultTransport
+	}
+	return admin.NewAdminClient(ctx, &http.Client{Transport: transport}, adminAddressPath)
 }
 
 // StartupHook runs once the Envoy admin server is ready. Configure this

--- a/internal/admin/admin.go
+++ b/internal/admin/admin.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"net/url"
 	"os"
@@ -24,8 +25,12 @@ import (
 const (
 	ServerAddr      = "127.0.0.1:9901"
 	AddressPathFlag = "--admin-address-path"
+	runIDFlag       = "--run-id"
 	live            = "live"
+	pollInterval    = 50 * time.Millisecond
 )
+
+var errMultipleEnvoyProcesses = fmt.Errorf("multiple Envoy processes found; set %s to disambiguate", runIDFlag)
 
 // NewAdminClient creates an AdminClient by polling for the admin port at
 // adminAddressPath.
@@ -192,7 +197,7 @@ func (c *adminClient) Get(ctx context.Context, path string) ([]byte, error) {
 // pollAdminAddressPathForPort polls for the admin-address.txt file.
 // It returns the admin port number or an error if the timeout is reached.
 func pollAdminAddressPathForPort(ctx context.Context, adminAddressPath string) (int, error) {
-	ticker := time.NewTicker(50 * time.Millisecond)
+	ticker := time.NewTicker(pollInterval)
 	defer ticker.Stop()
 
 	var adminAddr string
@@ -221,29 +226,36 @@ LOOP:
 		}
 	}
 
-	// Parse as a URL so hostnames, IPv4, and bracketed IPv6 addresses share
-	// one port extraction path.
-	u, err := url.Parse("http://" + adminAddr)
+	return parseAdminPort(adminAddr)
+}
+
+func parseAdminPort(addr string) (int, error) {
+	_, portStr, err := net.SplitHostPort(addr)
 	if err != nil {
 		return 0, fmt.Errorf("failed to parse Envoy's admin address: %w", err)
 	}
 
-	port, err := strconv.Atoi(u.Port())
+	port, err := strconv.Atoi(portStr)
 	if err != nil {
 		return 0, fmt.Errorf("failed to parse Envoy's admin port: %w", err)
 	}
-
 	return port, nil
 }
 
-// extractFlagValue parses a flag value from command line arguments.
-func extractFlagValue(flag string, cmdline []string) (string, error) {
-	for i, arg := range cmdline {
-		if arg == flag && i+1 < len(cmdline) && cmdline[i+1] != "" {
-			return cmdline[i+1], nil
+// extractAdminAddressPath returns the first match before [internalapi.ArgsIgnoreRest].
+func extractAdminAddressPath(cmdline []string) (string, error) {
+	for i := range len(cmdline) {
+		arg := cmdline[i]
+		if arg == internalapi.ArgsIgnoreRest {
+			break
 		}
-		if value, ok := strings.CutPrefix(arg, flag+"="); ok && value != "" {
-			return value, nil
+		switch {
+		case arg == AddressPathFlag && i+1 < len(cmdline) && cmdline[i+1] != "":
+			return cmdline[i+1], nil
+		case strings.HasPrefix(arg, AddressPathFlag+"="):
+			if value := strings.TrimPrefix(arg, AddressPathFlag+"="); value != "" {
+				return value, nil
+			}
 		}
 	}
 
@@ -251,35 +263,129 @@ func extractFlagValue(flag string, cmdline []string) (string, error) {
 	// fallback after the argv-preserving scan so direct args can contain spaces.
 	if len(cmdline) >= 3 && cmdline[1] == "-c" {
 		fields := strings.Fields(cmdline[2])
-		for i, arg := range fields {
-			if arg == flag && i+1 < len(fields) && fields[i+1] != "" {
-				return fields[i+1], nil
+		for i := range len(fields) {
+			arg := fields[i]
+			if arg == internalapi.ArgsIgnoreRest {
+				break
 			}
-			if value, ok := strings.CutPrefix(arg, flag+"="); ok && value != "" {
-				return value, nil
+			switch {
+			case arg == AddressPathFlag && i+1 < len(fields) && fields[i+1] != "":
+				return fields[i+1], nil
+			case strings.HasPrefix(arg, AddressPathFlag+"="):
+				if value := strings.TrimPrefix(arg, AddressPathFlag+"="); value != "" {
+					return value, nil
+				}
 			}
 		}
 	}
 
-	return "", fmt.Errorf("%s not found in command line", flag)
+	return "", fmt.Errorf("%s not found in command line", AddressPathFlag)
 }
 
-// PollEnvoyPidAndAdminAddressPath polls for the Envoy child process and
-// extracts its pid and admin address path from its command line.
+// extractRunID returns the last match, so the func-e-appended value after [internalapi.ArgsIgnoreRest] wins.
+func extractRunID(cmdline []string) (string, error) {
+	var runID string
+	for i := 0; i < len(cmdline); i++ {
+		arg := cmdline[i]
+		switch {
+		case arg == runIDFlag && i+1 < len(cmdline) && cmdline[i+1] != "":
+			runID = cmdline[i+1]
+			i++
+		case strings.HasPrefix(arg, runIDFlag+"="):
+			if value := strings.TrimPrefix(arg, runIDFlag+"="); value != "" {
+				runID = value
+			}
+		}
+	}
+	if runID != "" {
+		return runID, nil
+	}
+
+	if len(cmdline) >= 3 && cmdline[1] == "-c" {
+		fields := strings.Fields(cmdline[2])
+		for i := 0; i < len(fields); i++ {
+			arg := fields[i]
+			switch {
+			case arg == runIDFlag && i+1 < len(fields) && fields[i+1] != "":
+				runID = fields[i+1]
+				i++
+			case strings.HasPrefix(arg, runIDFlag+"="):
+				if value := strings.TrimPrefix(arg, runIDFlag+"="); value != "" {
+					runID = value
+				}
+			}
+		}
+	}
+	if runID != "" {
+		return runID, nil
+	}
+
+	return "", fmt.Errorf("%s not found in command line", runIDFlag)
+}
+
+type envoyProcessCandidate struct {
+	pid     int
+	cmdline []string
+}
+
+func selectEnvoyProcess(candidates []envoyProcessCandidate, runID string) (envoyPid int, adminAddressPath string, err error) {
+	if runID == "" {
+		// Without an explicit runID, skip children that lack the func-e marker.
+		foundRunID := false
+		for _, candidate := range candidates {
+			if _, err := extractRunID(candidate.cmdline); err != nil {
+				continue
+			}
+			foundRunID = true
+
+			path, err := extractAdminAddressPath(candidate.cmdline)
+			if err != nil {
+				continue
+			}
+			// Keep scanning past the first match to detect ambiguity.
+			if adminAddressPath != "" {
+				return 0, "", errMultipleEnvoyProcesses
+			}
+			envoyPid = candidate.pid
+			adminAddressPath = path
+		}
+		if adminAddressPath != "" {
+			return envoyPid, adminAddressPath, nil
+		}
+		if !foundRunID {
+			return 0, "", fmt.Errorf("no child with %s", runIDFlag)
+		}
+		return 0, "", fmt.Errorf("no child with %s", AddressPathFlag)
+	}
+
+	for _, candidate := range candidates {
+		id, err := extractRunID(candidate.cmdline)
+		if err != nil || id != runID {
+			continue
+		}
+		adminAddressPath, err := extractAdminAddressPath(candidate.cmdline)
+		if err != nil {
+			return 0, "", err
+		}
+		return candidate.pid, adminAddressPath, nil
+	}
+	return 0, "", fmt.Errorf("no child with %s %s", runIDFlag, runID)
+}
+
+// PollEnvoyPidAndAdminAddressPath polls for a child process tagged with
+// runID and extracts its pid and admin address path from its command line.
 //
-// This polls as the goroutine may be called prior to the Envoy subprocess.
-func PollEnvoyPidAndAdminAddressPath(ctx context.Context, funcEPid int) (envoyPid int, adminAddressPath string, err error) {
+// This polls because the child may not exist yet when the caller starts.
+func PollEnvoyPidAndAdminAddressPath(ctx context.Context, funcEPid int, runID string) (envoyPid int, adminAddressPath string, err error) {
 	funcEProc, err := process.NewProcessWithContext(ctx, int32(funcEPid)) //nolint:gosec // funcEPid never overflows int32
 	if err != nil {
 		return 0, "", fmt.Errorf("failed to get func-e process: %w", err)
 	}
 
-	ticker := time.NewTicker(50 * time.Millisecond)
+	ticker := time.NewTicker(pollInterval)
 	defer ticker.Stop()
 
-	var envoyProc *process.Process
 	var lastErr error
-LOOP:
 	for {
 		select {
 		case <-ctx.Done():
@@ -299,22 +405,27 @@ LOOP:
 				continue
 			}
 
-			// func-e starts one Envoy child process.
-			envoyProc = children[0]
-			envoyPid = int(envoyProc.Pid)
-			break LOOP
+			candidates := make([]envoyProcessCandidate, 0, len(children))
+			for _, child := range children {
+				cmdline, err := child.CmdlineSliceWithContext(ctx)
+				if err != nil {
+					continue
+				}
+				candidates = append(candidates, envoyProcessCandidate{
+					pid:     int(child.Pid),
+					cmdline: cmdline,
+				})
+			}
+
+			envoyPid, adminAddressPath, err = selectEnvoyProcess(candidates, runID)
+			if err == nil {
+				return envoyPid, adminAddressPath, nil
+			}
+			// Ambiguity won't resolve with more polling; the caller needs a runID.
+			if errors.Is(err, errMultipleEnvoyProcesses) {
+				return 0, "", err
+			}
+			lastErr = err
 		}
 	}
-
-	envoyCmdline, err := envoyProc.CmdlineSliceWithContext(ctx)
-	if err != nil {
-		return 0, "", fmt.Errorf("failed to get command line of Envoy: %w", err)
-	}
-
-	adminAddressPath, err = extractFlagValue(AddressPathFlag, envoyCmdline)
-	if err != nil {
-		return 0, "", err
-	}
-
-	return envoyPid, adminAddressPath, nil
 }

--- a/internal/admin/admin_test.go
+++ b/internal/admin/admin_test.go
@@ -88,7 +88,7 @@ func TestPollEnvoyPidAndAdminAddressPathForPort(t *testing.T) {
 				require.NoError(t, os.WriteFile(path, []byte("invalid-address"), 0o600))
 			},
 			ctx:         func(t *testing.T) context.Context { t.Helper(); return t.Context() },
-			expectedErr: "failed to parse Envoy's admin port: strconv.Atoi: parsing \"\": invalid syntax",
+			expectedErr: "failed to parse Envoy's admin address: address invalid-address: missing port in address",
 		},
 	}
 
@@ -155,6 +155,33 @@ func TestPollAdminAddressPathForPort_PollsOnTickerBoundary(t *testing.T) {
 		require.NoError(t, res.err)
 		require.Equal(t, 9901, res.port)
 	})
+}
+
+func TestParseAdminPort(t *testing.T) {
+	tests := []struct {
+		name        string
+		address     string
+		expected    int
+		expectedErr string
+	}{
+		{"ipv4", "127.0.0.1:9901", 9901, ""},
+		{"hostname", "localhost:9901", 9901, ""},
+		{"ipv6", "[::1]:9901", 9901, ""},
+		{"missing port", "invalid-address", 0, "failed to parse Envoy's admin address: address invalid-address: missing port in address"},
+		{"invalid port", "127.0.0.1:not-a-number", 0, "failed to parse Envoy's admin port: strconv.Atoi: parsing \"not-a-number\": invalid syntax"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actual, err := parseAdminPort(tt.address)
+			if tt.expectedErr != "" {
+				require.EqualError(t, err, tt.expectedErr)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tt.expected, actual)
+		})
+	}
 }
 
 func TestAdminClient_get(t *testing.T) {
@@ -351,34 +378,38 @@ func TestAdminClient_NewListenerRequest(t *testing.T) {
 	}
 }
 
-func TestExtractFlagValue(t *testing.T) {
+func TestExtractAdminAddressPath(t *testing.T) {
 	tmpDir := t.TempDir()
 	tmpFile := filepath.Join(tmpDir, "admin-address.txt")
 	pathWithSpaces := filepath.Join(tmpDir, "admin address.txt")
 
 	tests := []struct {
 		name        string
-		flag        string
 		cmdline     []string
 		expected    string
 		expectedErr string
 	}{
-		{"valid flag with path", AddressPathFlag, []string{"envoy", AddressPathFlag, tmpDir}, tmpDir, ""},
-		{"valid flag with path containing spaces", AddressPathFlag, []string{"envoy", AddressPathFlag, pathWithSpaces}, pathWithSpaces, ""},
-		{"valid equals flag", AddressPathFlag, []string{"envoy", AddressPathFlag + "=" + tmpFile}, tmpFile, ""},
-		{"flag at end with path", AddressPathFlag, []string{"--config", "/etc/envoy.yaml", AddressPathFlag, tmpDir}, tmpDir, ""},
-		{"flag not present", AddressPathFlag, []string{"envoy", "--config", "/etc/envoy.yaml"}, "", AddressPathFlag + " not found in command line"},
-		{"flag present but no value", AddressPathFlag, []string{"envoy", AddressPathFlag}, "", AddressPathFlag + " not found in command line"},
-		{"empty cmdline", AddressPathFlag, []string{}, "", AddressPathFlag + " not found in command line"},
-		{"sh -c wrapped command", AddressPathFlag, []string{"sh", "-c", fmt.Sprintf("sleep 30 && echo %s %s", AddressPathFlag, tmpDir)}, tmpDir, ""},
-		{"sh -c with multiple spaces", AddressPathFlag, []string{"sh", "-c", fmt.Sprintf("envoy %s %s --other-flag", AddressPathFlag, tmpDir)}, tmpDir, ""},
-		{"sh -c with equals flag", AddressPathFlag, []string{"sh", "-c", fmt.Sprintf("envoy %s=%s --other-flag", AddressPathFlag, tmpFile)}, tmpFile, ""},
-		{"admin address path flag", AddressPathFlag, []string{"envoy", AddressPathFlag, tmpFile}, tmpFile, ""},
+		{"reads value form before Envoy ignore-rest", []string{"envoy", AddressPathFlag, tmpDir}, tmpDir, ""},
+		{"preserves spaces in direct argv value", []string{"envoy", AddressPathFlag, pathWithSpaces}, pathWithSpaces, ""},
+		{"reads equals form before Envoy ignore-rest", []string{"envoy", AddressPathFlag + "=" + tmpFile}, tmpFile, ""},
+		{"finds value after other Envoy-owned args", []string{"--config", "/etc/envoy.yaml", AddressPathFlag, tmpDir}, tmpDir, ""},
+		{"flag not present", []string{"envoy", "--config", "/etc/envoy.yaml"}, "", AddressPathFlag + " not found in command line"},
+		{"flag present but no value", []string{"envoy", AddressPathFlag}, "", AddressPathFlag + " not found in command line"},
+		{"empty cmdline", []string{}, "", AddressPathFlag + " not found in command line"},
+		{"ignores value form hidden behind Envoy ignore-rest", []string{"envoy", "--", AddressPathFlag, tmpDir}, "", AddressPathFlag + " not found in command line"},
+		{"keeps earlier equals form when later value is hidden", []string{"envoy", AddressPathFlag + "=" + tmpFile, "--", AddressPathFlag, tmpDir}, tmpFile, ""},
+		{"accepts ignore-rest token as the flag value", []string{"envoy", AddressPathFlag, "--"}, "--", ""},
+		{"reads value form from shell-wrapped command", []string{"sh", "-c", fmt.Sprintf("sleep 30 && echo %s %s", AddressPathFlag, tmpDir)}, tmpDir, ""},
+		{"reads value form from shell wrapper with extra args", []string{"sh", "-c", fmt.Sprintf("envoy %s %s --other-flag", AddressPathFlag, tmpDir)}, tmpDir, ""},
+		{"reads equals form from shell-wrapped command", []string{"sh", "-c", fmt.Sprintf("envoy %s=%s --other-flag", AddressPathFlag, tmpFile)}, tmpFile, ""},
+		{"ignores shell-wrapped value hidden behind Envoy ignore-rest", []string{"sh", "-c", fmt.Sprintf("envoy -- %s %s", AddressPathFlag, tmpDir)}, "", AddressPathFlag + " not found in command line"},
+		{"keeps shell-wrapped equals form before ignore-rest", []string{"sh", "-c", fmt.Sprintf("envoy %s=%s -- %s %s", AddressPathFlag, tmpFile, AddressPathFlag, tmpDir)}, tmpFile, ""},
+		{"accepts ignore-rest token as shell-wrapped value", []string{"sh", "-c", fmt.Sprintf("envoy %s --", AddressPathFlag)}, "--", ""},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			actual, err := extractFlagValue(tt.flag, tt.cmdline)
+			actual, err := extractAdminAddressPath(tt.cmdline)
 			if tt.expectedErr != "" {
 				require.EqualError(t, err, tt.expectedErr)
 			} else {
@@ -389,15 +420,173 @@ func TestExtractFlagValue(t *testing.T) {
 	}
 }
 
+func TestExtractRunID(t *testing.T) {
+	tests := []struct {
+		name        string
+		cmdline     []string
+		expected    string
+		expectedErr string
+	}{
+		{"finds func-e marker after Envoy ignore-rest", []string{"envoy", "--", runIDFlag, "run-1"}, "run-1", ""},
+		{"finds equals-form func-e marker after Envoy ignore-rest", []string{"envoy", "--", runIDFlag + "=run-1"}, "run-1", ""},
+		{"finds func-e marker in shell-wrapped command", []string{"sh", "-c", "envoy -- --run-id run-1"}, "run-1", ""},
+		{"finds shell-wrapped equals-form func-e marker", []string{"sh", "-c", "envoy -- --run-id=run-1"}, "run-1", ""},
+		{"uses appended func-e marker over Envoy-owned value", []string{"envoy", runIDFlag, "ignored", "--", runIDFlag, "run-2"}, "run-2", ""},
+		{"uses shell-wrapped appended marker over Envoy-owned value", []string{"sh", "-c", "envoy --run-id ignored -- --run-id run-2"}, "run-2", ""},
+		{"requires func-e marker for process matching", []string{"envoy", "--", "--other", "value"}, "", runIDFlag + " not found in command line"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actual, err := extractRunID(tt.cmdline)
+			if tt.expectedErr != "" {
+				require.EqualError(t, err, tt.expectedErr)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tt.expected, actual)
+			}
+		})
+	}
+}
+
+func TestSelectEnvoyProcess(t *testing.T) {
+	tests := []struct {
+		name         string
+		candidates   []envoyProcessCandidate
+		runID        string
+		expectedPID  int
+		expectedPath string
+		expectedErr  string
+	}{
+		{
+			name: "explicit run id selects the matching func-e-launched Envoy",
+			candidates: []envoyProcessCandidate{
+				{pid: 1, cmdline: []string{"envoy", AddressPathFlag, "/tmp/admin-1.txt", "--", runIDFlag, "run-1"}},
+				{pid: 2, cmdline: []string{"envoy", AddressPathFlag, "/tmp/admin-2.txt", "--", runIDFlag, "run-2"}},
+			},
+			runID:        "run-2",
+			expectedPID:  2,
+			expectedPath: "/tmp/admin-2.txt",
+		},
+		{
+			name: "explicit run id does not trust Envoy flags hidden behind ignore-rest",
+			candidates: []envoyProcessCandidate{
+				{pid: 1, cmdline: []string{"envoy", "--", AddressPathFlag, "/tmp/admin-1.txt", runIDFlag, "run-1"}},
+			},
+			runID:       "run-1",
+			expectedErr: AddressPathFlag + " not found in command line",
+		},
+		{
+			name: "fallback skips BOE ext_proc sibling because it has no func-e marker",
+			candidates: []envoyProcessCandidate{
+				{pid: 1, cmdline: []string{"/var/boe/data/extensions/extproc/example-ext-proc/0.1.0/ext_proc-server", "--port", "50051"}},
+				{pid: 2, cmdline: []string{"envoy", AddressPathFlag, "/tmp/admin-2.txt", "--", runIDFlag, "run-2"}},
+			},
+			expectedPID:  2,
+			expectedPath: "/tmp/admin-2.txt",
+		},
+		{
+			name: "fallback does not identify Envoy by admin flag alone",
+			candidates: []envoyProcessCandidate{
+				{pid: 1, cmdline: []string{"envoy", AddressPathFlag, "/tmp/admin-1.txt"}},
+			},
+			expectedErr: "no child with " + runIDFlag,
+		},
+		{
+			name: "fallback refuses to guess between multiple func-e-launched Envoys",
+			candidates: []envoyProcessCandidate{
+				{pid: 1, cmdline: []string{"envoy", AddressPathFlag, "/tmp/admin-1.txt", "--", runIDFlag, "run-1"}},
+				{pid: 2, cmdline: []string{"envoy", AddressPathFlag, "/tmp/admin-2.txt", "--", runIDFlag, "run-2"}},
+			},
+			expectedErr: errMultipleEnvoyProcesses.Error(),
+		},
+		{
+			name: "fallback still applies Envoy ignore-rest before reading admin path",
+			candidates: []envoyProcessCandidate{
+				{pid: 1, cmdline: []string{"envoy", "--", AddressPathFlag, "/tmp/ignored.txt", runIDFlag, "run-1"}},
+			},
+			expectedErr: "no child with " + AddressPathFlag,
+		},
+		{
+			name: "explicit run id fails when no child has the matching marker",
+			candidates: []envoyProcessCandidate{
+				{pid: 1, cmdline: []string{"envoy", AddressPathFlag, "/tmp/admin-1.txt", "--", runIDFlag, "run-1"}},
+			},
+			runID:       "run-2",
+			expectedErr: "no child with " + runIDFlag + " run-2",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actualPID, actualPath, err := selectEnvoyProcess(tt.candidates, tt.runID)
+			if tt.expectedErr != "" {
+				require.EqualError(t, err, tt.expectedErr)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tt.expectedPID, actualPID)
+			require.Equal(t, tt.expectedPath, actualPath)
+		})
+	}
+}
+
 func TestPollEnvoyPidAndAdminAddressPath(t *testing.T) {
-	t.Run("success - finds envoy PID and defaults admin address path", func(t *testing.T) {
+	t.Run("uses run id to choose between live child processes", func(t *testing.T) {
 		ctx, cancel := context.WithCancel(t.Context())
 		t.Cleanup(cancel)
 
-		adminAddressPath := path.Join(t.TempDir(), "admin-address.txt")
+		path1 := path.Join(t.TempDir(), "admin-1.txt")
+		path2 := path.Join(t.TempDir(), "admin-2.txt")
 
-		cmdStr := "sleep 30 && echo --admin-address-path " + adminAddressPath
-		cmd := exec.CommandContext(ctx, "sh", "-c", cmdStr)
+		cmd1 := exec.CommandContext(ctx, "sh", "-c",
+			fmt.Sprintf("sleep 30 && echo %s %s -- --run-id run-1", AddressPathFlag, path1))
+		cmd2 := exec.CommandContext(ctx, "sh", "-c",
+			fmt.Sprintf("sleep 30 && echo %s %s -- --run-id run-2", AddressPathFlag, path2))
+		require.NoError(t, cmd1.Start())
+		require.NoError(t, cmd2.Start())
+		t.Cleanup(func() {
+			cmd1.Process.Kill()
+			cmd1.Process.Wait()
+			cmd2.Process.Kill()
+			cmd2.Process.Wait()
+		})
+
+		time.Sleep(100 * time.Millisecond)
+
+		tests := []struct {
+			name        string
+			runID       string
+			expectedPID int
+			expected    string
+			expectedErr string
+		}{
+			{"selects first marked Envoy", "run-1", cmd1.Process.Pid, path1, ""},
+			{"selects second marked Envoy", "run-2", cmd2.Process.Pid, path2, ""},
+			{"requires run id when multiple marked Envoys are live", "", 0, "", "multiple Envoy processes found; set --run-id to disambiguate"},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				actualEnvoyPid, actualAdminAddressPath, err := PollEnvoyPidAndAdminAddressPath(t.Context(), os.Getpid(), tt.runID)
+				if tt.expectedErr != "" {
+					require.EqualError(t, err, tt.expectedErr)
+					return
+				}
+				require.NoError(t, err)
+				require.Equal(t, tt.expectedPID, actualEnvoyPid)
+				require.Equal(t, tt.expected, actualAdminAddressPath)
+			})
+		}
+	})
+
+	t.Run("fallback selects the only marked live Envoy", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(t.Context())
+		t.Cleanup(cancel)
+
+		adminAddressPath := path.Join(t.TempDir(), "admin.txt")
+		cmd := exec.CommandContext(ctx, "sh", "-c",
+			fmt.Sprintf("sleep 30 && echo %s %s -- --run-id ignored", AddressPathFlag, adminAddressPath))
 		require.NoError(t, cmd.Start())
 		t.Cleanup(func() {
 			cmd.Process.Kill()
@@ -406,17 +595,17 @@ func TestPollEnvoyPidAndAdminAddressPath(t *testing.T) {
 
 		time.Sleep(100 * time.Millisecond)
 
-		actualEnvoyPid, actualAdminAddressPath, err := PollEnvoyPidAndAdminAddressPath(t.Context(), os.Getpid())
+		actualEnvoyPid, actualAdminAddressPath, err := PollEnvoyPidAndAdminAddressPath(t.Context(), os.Getpid(), "")
 		require.NoError(t, err)
 		require.Equal(t, cmd.Process.Pid, actualEnvoyPid)
 		require.Equal(t, adminAddressPath, actualAdminAddressPath)
 	})
 
-	t.Run("failure - timeout waiting for Envoy process", func(t *testing.T) {
+	t.Run("times out when no child process is available", func(t *testing.T) {
 		ctx, cancel := context.WithTimeout(t.Context(), 200*time.Millisecond)
 		t.Cleanup(cancel)
 
-		_, _, err := PollEnvoyPidAndAdminAddressPath(ctx, os.Getpid())
+		_, _, err := PollEnvoyPidAndAdminAddressPath(ctx, os.Getpid(), "")
 		require.EqualError(t, err, "timeout waiting for Envoy process: no Envoy process found")
 	})
 }
@@ -448,7 +637,7 @@ func TestNewAdminClient(t *testing.T) {
 				require.NoError(t, os.WriteFile(adminAddressPath, []byte("not-a-number"), 0o600))
 			},
 			ctx:         func(t *testing.T) context.Context { t.Helper(); return t.Context() },
-			expectedErr: "failed to parse Envoy's admin port: strconv.Atoi: parsing \"\": invalid syntax",
+			expectedErr: "failed to parse Envoy's admin address: address not-a-number: missing port in address",
 		},
 		{
 			name: "returns error when admin address file never appears",

--- a/internal/api/opts.go
+++ b/internal/api/opts.go
@@ -10,6 +10,9 @@ import (
 	"net/http"
 )
 
+// ArgsIgnoreRest is Envoy's CLI separator: args after this are not parsed.
+const ArgsIgnoreRest = "--"
+
 // HTTPTransport creates the HTTP client transport used during a run.
 type HTTPTransport func() http.RoundTripper
 

--- a/internal/envoy/config/config.go
+++ b/internal/envoy/config/config.go
@@ -9,6 +9,8 @@ import (
 	"strings"
 
 	"gopkg.in/yaml.v3"
+
+	internalapi "github.com/tetratelabs/func-e/internal/api"
 )
 
 type config struct {
@@ -141,6 +143,8 @@ func FindAdminAddressFromArgs(args []string) (string, error) {
 	for i := 0; i < len(args); i++ {
 		arg := args[i]
 		switch {
+		case arg == internalapi.ArgsIgnoreRest:
+			return FindAdminAddress(configPath, configYaml)
 		case arg == "-c" || arg == "--config-path":
 			if i+1 < len(args) {
 				configPath = args[i+1]

--- a/internal/envoy/config/config_test.go
+++ b/internal/envoy/config/config_test.go
@@ -4,6 +4,7 @@
 package config
 
 import (
+	"os"
 	"path/filepath"
 	"runtime"
 	"testing"
@@ -36,13 +37,13 @@ func TestParseListeners(t *testing.T) {
 		name        string
 		configPath  string
 		configYaml  string
-		expect      *Config
+		expected    *Config
 		expectedErr string
 	}{
 		{
 			name:       "admin_localhost",
 			configPath: adminLocalhostPath,
-			expect: &Config{
+			expected: &Config{
 				Admin: admin.ServerAddr,
 				StaticListeners: []Listener{{
 					Name:    "test_listener",
@@ -53,7 +54,7 @@ func TestParseListeners(t *testing.T) {
 		{
 			name:       "admin_ephemeral",
 			configPath: adminEphemeralPath,
-			expect: &Config{
+			expected: &Config{
 				Admin: "127.0.0.1:0",
 				StaticListeners: []Listener{{
 					Name:    "test_listener",
@@ -64,7 +65,7 @@ func TestParseListeners(t *testing.T) {
 		{
 			name:       "no_admin",
 			configPath: noAdminPath,
-			expect: &Config{
+			expected: &Config{
 				Admin: "",
 				StaticListeners: []Listener{{
 					Name:    "test_listener",
@@ -75,7 +76,7 @@ func TestParseListeners(t *testing.T) {
 		{
 			name:       "access_log",
 			configPath: accessLogPath,
-			expect: &Config{
+			expected: &Config{
 				Admin: "127.0.0.1:0",
 				StaticListeners: []Listener{{
 					Name:    "main",
@@ -113,7 +114,7 @@ http_filters:
 		{
 			name:       "static_file",
 			configPath: staticFilePath,
-			expect: &Config{
+			expected: &Config{
 				Admin: "",
 				StaticListeners: []Listener{{
 					Name:    "main",
@@ -135,7 +136,7 @@ http_filters:
 			name:       "mixed_config_path_and_yaml_last_wins",
 			configPath: adminLocalhostPath,
 			configYaml: `admin: {address: {socket_address: {address: "127.0.0.3", port_value: 9903}}}`,
-			expect: &Config{
+			expected: &Config{
 				Admin: "127.0.0.3:9903",
 				StaticListeners: []Listener{{
 					Name:    "test_listener",
@@ -147,7 +148,7 @@ http_filters:
 			name:       "mixed_config_path_and_yaml_yaml_always_wins",
 			configPath: adminEphemeralPath,
 			configYaml: `admin: {address: {socket_address: {address: "127.0.0.3", port_value: 9903}}}`,
-			expect: &Config{
+			expected: &Config{
 				Admin: "127.0.0.3:9903",
 				StaticListeners: []Listener{{
 					Name:    "test_listener",
@@ -158,7 +159,7 @@ http_filters:
 		{
 			name:       "udp_proxy",
 			configPath: udpProxyPath,
-			expect: &Config{
+			expected: &Config{
 				Admin: "",
 				StaticListeners: []Listener{{
 					Name:     "udp_listener",
@@ -190,7 +191,7 @@ matcher:
 				require.EqualError(t, err, tt.expectedErr)
 			} else {
 				require.NoError(t, err)
-				require.Equal(t, tt.expect, result)
+				require.Equal(t, tt.expected, result)
 			}
 		})
 	}
@@ -206,28 +207,28 @@ func TestFindAdminAddress(t *testing.T) {
 		name        string
 		configPath  string
 		configYaml  string
-		expect      string
+		expected    string
 		expectedErr string
 	}{
 		{
 			name:       "file_with_admin",
 			configPath: adminLocalhostPath,
-			expect:     admin.ServerAddr,
+			expected:   admin.ServerAddr,
 		},
 		{
 			name:       "file_without_admin",
 			configPath: noAdminPath,
-			expect:     "",
+			expected:   "",
 		},
 		{
 			name:       "config_with_admin",
 			configYaml: `admin: {address: {socket_address: {address: "127.0.0.1", port_value: 9901}}}`,
-			expect:     admin.ServerAddr,
+			expected:   admin.ServerAddr,
 		},
 		{
 			name:       "config_without_admin",
 			configYaml: `static_resources: {listeners: [{name: test_listener}]}`,
-			expect:     "",
+			expected:   "",
 		},
 	}
 
@@ -238,7 +239,7 @@ func TestFindAdminAddress(t *testing.T) {
 				require.EqualError(t, err, tt.expectedErr)
 			} else {
 				require.NoError(t, err)
-				require.Equal(t, tt.expect, hostPort)
+				require.Equal(t, tt.expected, hostPort)
 			}
 		})
 	}
@@ -249,31 +250,42 @@ func TestFindAdminAddressFromArgs(t *testing.T) {
 
 	adminLocalhostPath := filepath.Join(testdataDir, "admin_localhost.yaml")
 	adminYaml := `admin: {address: {socket_address: {address: "127.0.0.3", port_value: 9903}}}`
+	ignoredAdminYaml := `admin: {address: {socket_address: {address: "127.0.0.4", port_value: 9904}}}`
 
 	tests := []struct {
-		name   string
-		args   []string
-		expect string
+		name     string
+		args     []string
+		expected string
 	}{
 		{
-			name:   "config path value",
-			args:   []string{"--config-path", adminLocalhostPath},
-			expect: admin.ServerAddr,
+			name:     "reads admin from config path value",
+			args:     []string{"--config-path", adminLocalhostPath},
+			expected: admin.ServerAddr,
 		},
 		{
-			name:   "config path equals",
-			args:   []string{"--config-path=" + adminLocalhostPath},
-			expect: admin.ServerAddr,
+			name:     "reads admin from config path equals form",
+			args:     []string{"--config-path=" + adminLocalhostPath},
+			expected: admin.ServerAddr,
 		},
 		{
-			name:   "config yaml value",
-			args:   []string{"--config-yaml", adminYaml},
-			expect: "127.0.0.3:9903",
+			name:     "reads admin from config yaml value",
+			args:     []string{"--config-yaml", adminYaml},
+			expected: "127.0.0.3:9903",
 		},
 		{
-			name:   "config yaml equals",
-			args:   []string{"--config-yaml=" + adminYaml},
-			expect: "127.0.0.3:9903",
+			name:     "reads admin from config yaml equals form",
+			args:     []string{"--config-yaml=" + adminYaml},
+			expected: "127.0.0.3:9903",
+		},
+		{
+			name:     "ignores config hidden behind Envoy ignore-rest",
+			args:     []string{"--", "--config-yaml", adminYaml},
+			expected: "",
+		},
+		{
+			name:     "uses config before Envoy ignore-rest when later config is hidden",
+			args:     []string{"--config-yaml=" + adminYaml, "--", "--config-yaml", ignoredAdminYaml},
+			expected: "127.0.0.3:9903",
 		},
 	}
 
@@ -281,7 +293,17 @@ func TestFindAdminAddressFromArgs(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			hostPort, err := FindAdminAddressFromArgs(tt.args)
 			require.NoError(t, err)
-			require.Equal(t, tt.expect, hostPort)
+			require.Equal(t, tt.expected, hostPort)
 		})
 	}
+
+	t.Run("accepts ignore-rest token as config path value", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		require.NoError(t, os.WriteFile(filepath.Join(tmpDir, "--"), []byte(adminYaml), 0o600))
+		t.Chdir(tmpDir)
+
+		hostPort, err := FindAdminAddressFromArgs([]string{"--config-path", "--"})
+		require.NoError(t, err)
+		require.Equal(t, "127.0.0.3:9903", hostPort)
+	})
 }

--- a/internal/envoy/run.go
+++ b/internal/envoy/run.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/tetratelabs/func-e/internal/admin"
+	internalapi "github.com/tetratelabs/func-e/internal/api"
 )
 
 // Run execs the Envoy binary at the path with the args passed.
@@ -28,6 +29,9 @@ func (r *Runtime) Run(ctx context.Context, args []string) error {
 
 	// Ensure a re-run in the same directory has no stale admin-address file
 	os.RemoveAll(adminAddressPath) //nolint:errcheck,gosec // missing path is the desired state
+
+	// Tag the process so NewAdminClient can find it among sibling processes.
+	args = append(args, internalapi.ArgsIgnoreRest, "--run-id", r.o.RunID)
 
 	cmd := exec.CommandContext(ctx, r.o.EnvoyPath, args...) // #nosec -> users can run whatever binary they like!
 	cmd.Stdout = r.Out

--- a/internal/envoy/run_test.go
+++ b/internal/envoy/run_test.go
@@ -39,6 +39,7 @@ func TestRuntime_Run_EnvoyError(t *testing.T) {
 		HTTPClient: http.DefaultClient,
 		RunDir:     runDir,
 		TempDir:    runDir,
+		RunID:      "test-run-id",
 	}, logToOutput)
 	r.Out, r.Err = stdout, stderr
 
@@ -54,6 +55,7 @@ func TestRuntime_Run_EnvoyError(t *testing.T) {
 			"--config-yaml", "invalid.yaml",
 			// test we added additional arguments
 			admin.AddressPathFlag, filepath.Join(runDir, "admin-address.txt"),
+			"--", "--run-id", "test-run-id",
 		}, r.cmd.Args, "command arguments mismatch")
 		require.Empty(t, r.cmd.Dir, "working directory should be empty")
 	})
@@ -80,7 +82,7 @@ func TestRuntime_Run_StartupHook(t *testing.T) {
 		name        string
 		startupHook internalapi.StartupHook
 		expectedErr string
-		expectLog   string
+		expectedLog string
 		envoyArgs   []string
 	}{
 		{
@@ -89,7 +91,7 @@ func TestRuntime_Run_StartupHook(t *testing.T) {
 				return errors.New("database connection failed")
 			},
 			expectedErr: "database connection failed",
-			expectLog:   "database connection failed",
+			expectedLog: "database connection failed",
 			envoyArgs: []string{
 				"--config-yaml", "admin: {address: {socket_address: {address: '127.0.0.1', port_value: 0}}}",
 			},
@@ -100,7 +102,7 @@ func TestRuntime_Run_StartupHook(t *testing.T) {
 				panic("nil pointer dereference")
 			},
 			expectedErr: "startup hook panicked: nil pointer dereference",
-			expectLog:   "startup hook panicked: nil pointer dereference",
+			expectedLog: "startup hook panicked: nil pointer dereference",
 			envoyArgs: []string{
 				"--config-yaml", "admin: {address: {socket_address: {address: '127.0.0.1', port_value: 0}}}",
 			},
@@ -111,7 +113,7 @@ func TestRuntime_Run_StartupHook(t *testing.T) {
 				logToOutput("startup hook executed successfully")
 				return nil
 			},
-			expectLog: "startup hook executed successfully",
+			expectedLog: "startup hook executed successfully",
 			envoyArgs: []string{
 				"--config-yaml", "admin: {address: {socket_address: {address: '127.0.0.1', port_value: 0}}}",
 			},
@@ -158,8 +160,8 @@ func TestRuntime_Run_StartupHook(t *testing.T) {
 			}
 
 			// Check log output
-			if tt.expectLog != "" {
-				require.Contains(t, logBuf.String(), tt.expectLog)
+			if tt.expectedLog != "" {
+				require.Contains(t, logBuf.String(), tt.expectedLog)
 			}
 
 			// Verify the process is dead

--- a/internal/envoy/runtime.go
+++ b/internal/envoy/runtime.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"slices"
 	"strings"
 	"syscall"
 	"time"
@@ -85,10 +86,14 @@ func (r *Runtime) String() string {
 func ensureAdminAddress(logf LogFunc, runDir string, argsIn []string) (adminAddressPath string, args []string, err error) {
 	args = argsIn
 	var hasConfig bool
+	insertAt := len(args)
 ARGS:
 	for i := 0; i < len(args); i++ {
 		arg := args[i]
 		switch {
+		case arg == internalapi.ArgsIgnoreRest:
+			insertAt = i
+			break ARGS
 		case arg == "-c" || arg == "--config-path" || arg == configYamlFlag:
 			i++
 			if i < len(args) {
@@ -134,13 +139,14 @@ ARGS:
 		logf("failed to find admin address: %s", err)
 	} else if adminAddress == "" {
 		logf("configuring ephemeral admin server")
-		args = append(args, configYamlFlag, adminEphemeralConfig)
+		args = slices.Insert(args, insertAt, configYamlFlag, adminEphemeralConfig)
+		insertAt += 2
 	}
 
 	if adminAddressPath == "" {
 		// Envoy's run directory is mutable, so it is fine to write the admin address there.
 		adminAddressPath = filepath.Join(runDir, "admin-address.txt")
-		args = append(args, adminAddressPathFlag, adminAddressPath)
+		args = slices.Insert(args, insertAt, adminAddressPathFlag, adminAddressPath)
 	}
 	return adminAddressPath, args, nil
 }

--- a/internal/envoy/runtime_test.go
+++ b/internal/envoy/runtime_test.go
@@ -19,59 +19,79 @@ func TestEnsureAdminAddress(t *testing.T) {
 	runDir := t.TempDir()
 
 	runAdminAddressPath := filepath.Join(runDir, "admin-address.txt")
+	adminYaml := "admin: {address: {socket_address: {address: '127.0.0.1', port_value: 9901}}}"
+	noAdminYaml := "static_resources: {}"
 	tests := []struct {
-		name                   string
-		args                   []string
-		expectAdminAddressPath string
-		expectArgs             []string
-		expectLogs             string
+		name                     string
+		args                     []string
+		expectedAdminAddressPath string
+		expectedArgs             []string
+		expectedLogs             string
 	}{
 		{
-			name:       "no args", // allows envoy to fail properly if no args are provided
-			args:       []string{"envoy"},
-			expectArgs: []string{"envoy"},
-			expectLogs: "",
+			name:         "leaves missing config unchanged for Envoy to report",
+			args:         []string{"envoy"},
+			expectedArgs: []string{"envoy"},
+			expectedLogs: "",
 		},
 		{
-			name:       "empty config arg", // allows envoy to fail properly if no args are provided
-			args:       []string{"-c", ""},
-			expectArgs: []string{"-c", ""},
-			expectLogs: "",
+			name:         "leaves empty config value unchanged for Envoy to report",
+			args:         []string{"-c", ""},
+			expectedArgs: []string{"-c", ""},
+			expectedLogs: "",
 		},
 		{
-			name:                   "args",
-			args:                   []string{"-c", "/tmp/google_com_proxy.v2.yaml"},
-			expectAdminAddressPath: runAdminAddressPath,
-			expectArgs:             []string{"-c", "/tmp/google_com_proxy.v2.yaml", "--admin-address-path", runAdminAddressPath},
-			expectLogs:             "failed to find admin address: failed to read config file /tmp/google_com_proxy.v2.yaml: open /tmp/google_com_proxy.v2.yaml: no such file or directory\n",
+			name:                     "adds admin path when bootstrap file cannot be inspected",
+			args:                     []string{"-c", "/tmp/google_com_proxy.v2.yaml"},
+			expectedAdminAddressPath: runAdminAddressPath,
+			expectedArgs:             []string{"-c", "/tmp/google_com_proxy.v2.yaml", "--admin-address-path", runAdminAddressPath},
+			expectedLogs:             "failed to find admin address: failed to read config file /tmp/google_com_proxy.v2.yaml: open /tmp/google_com_proxy.v2.yaml: no such file or directory\n",
 		},
 		{
-			name:                   "config path equals",
-			args:                   []string{"--config-path=/tmp/google_com_proxy.v2.yaml"},
-			expectAdminAddressPath: runAdminAddressPath,
-			expectArgs:             []string{"--config-path=/tmp/google_com_proxy.v2.yaml", "--admin-address-path", runAdminAddressPath},
-			expectLogs:             "failed to find admin address: failed to read config file /tmp/google_com_proxy.v2.yaml: open /tmp/google_com_proxy.v2.yaml: no such file or directory\n",
+			name:                     "adds admin path for equals-form config path",
+			args:                     []string{"--config-path=/tmp/google_com_proxy.v2.yaml"},
+			expectedAdminAddressPath: runAdminAddressPath,
+			expectedArgs:             []string{"--config-path=/tmp/google_com_proxy.v2.yaml", "--admin-address-path", runAdminAddressPath},
+			expectedLogs:             "failed to find admin address: failed to read config file /tmp/google_com_proxy.v2.yaml: open /tmp/google_com_proxy.v2.yaml: no such file or directory\n",
 		},
 		{
-			name:                   "config yaml equals",
-			args:                   []string{"--config-yaml=admin: {address: {socket_address: {address: '127.0.0.1', port_value: 9901}}}"},
-			expectAdminAddressPath: runAdminAddressPath,
-			expectArgs:             []string{"--config-yaml=admin: {address: {socket_address: {address: '127.0.0.1', port_value: 9901}}}", "--admin-address-path", runAdminAddressPath},
-			expectLogs:             "",
+			name:                     "adds admin path when config already has admin server",
+			args:                     []string{"--config-yaml=" + adminYaml},
+			expectedAdminAddressPath: runAdminAddressPath,
+			expectedArgs:             []string{"--config-yaml=" + adminYaml, "--admin-address-path", runAdminAddressPath},
+			expectedLogs:             "",
 		},
 		{
-			name:                   "already",
-			args:                   []string{"--admin-address-path", "/tmp/admin.txt", "-c", "/tmp/google_com_proxy.v2.yaml"},
-			expectAdminAddressPath: "/tmp/admin.txt",
-			expectArgs:             []string{"--admin-address-path", "/tmp/admin.txt", "-c", "/tmp/google_com_proxy.v2.yaml"},
-			expectLogs:             "failed to find admin address: failed to read config file /tmp/google_com_proxy.v2.yaml: open /tmp/google_com_proxy.v2.yaml: no such file or directory\n",
+			name:         "does not backfill from config hidden behind ignore-rest",
+			args:         []string{"--", "--config-yaml", adminYaml},
+			expectedArgs: []string{"--", "--config-yaml", adminYaml},
 		},
 		{
-			name:                   "already equals",
-			args:                   []string{"--admin-address-path=/tmp/admin.txt", "--config-path=/tmp/google_com_proxy.v2.yaml"},
-			expectAdminAddressPath: "/tmp/admin.txt",
-			expectArgs:             []string{"--admin-address-path=/tmp/admin.txt", "--config-path=/tmp/google_com_proxy.v2.yaml"},
-			expectLogs:             "failed to find admin address: failed to read config file /tmp/google_com_proxy.v2.yaml: open /tmp/google_com_proxy.v2.yaml: no such file or directory\n",
+			name:                     "does not trust admin path hidden behind ignore-rest",
+			args:                     []string{"--config-yaml=" + adminYaml, "--", "--admin-address-path", "/tmp/ignored-admin.txt"},
+			expectedAdminAddressPath: runAdminAddressPath,
+			expectedArgs:             []string{"--config-yaml=" + adminYaml, "--admin-address-path", runAdminAddressPath, "--", "--admin-address-path", "/tmp/ignored-admin.txt"},
+		},
+		{
+			name:                     "inserts generated admin args before ignore-rest",
+			args:                     []string{"--config-yaml", noAdminYaml, "--", "--log-level", "debug"},
+			expectedAdminAddressPath: runAdminAddressPath,
+			expectedArgs:             []string{"--config-yaml", noAdminYaml, "--config-yaml", adminEphemeralConfig, "--admin-address-path", runAdminAddressPath, "--", "--log-level", "debug"},
+			expectedLogs:             "configuring ephemeral admin server\n",
+		},
+		{
+			name:                     "keeps caller-provided admin path value",
+			args:                     []string{"--admin-address-path", "/tmp/admin.txt", "-c", "/tmp/google_com_proxy.v2.yaml"},
+			expectedAdminAddressPath: "/tmp/admin.txt",
+			expectedArgs:             []string{"--admin-address-path", "/tmp/admin.txt", "-c", "/tmp/google_com_proxy.v2.yaml"},
+			expectedLogs:             "failed to find admin address: failed to read config file /tmp/google_com_proxy.v2.yaml: open /tmp/google_com_proxy.v2.yaml: no such file or directory\n",
+		},
+		{
+			name:                     "keeps caller-provided admin path equals form",
+			args:                     []string{"--admin-address-path=/tmp/admin.txt", "--config-path=/tmp/google_com_proxy.v2.yaml"},
+			expectedAdminAddressPath: "/tmp/admin.txt",
+			expectedArgs:             []string{"--admin-address-path=/tmp/admin.txt", "--config-path=/tmp/google_com_proxy.v2.yaml"},
+			expectedLogs:             "failed to find admin address: failed to read config file /tmp/google_com_proxy.v2.yaml: open /tmp/google_com_proxy.v2.yaml: no such file or directory\n",
 		},
 	}
 
@@ -85,9 +105,9 @@ func TestEnsureAdminAddress(t *testing.T) {
 			adminAddressPath, args, err := ensureAdminAddress(logf, runDir, tt.args)
 			require.NoError(t, err)
 
-			require.Equal(t, tt.expectAdminAddressPath, adminAddressPath)
-			require.Equal(t, tt.expectArgs, args)
-			require.Equal(t, tt.expectLogs, logBuf.String())
+			require.Equal(t, tt.expectedAdminAddressPath, adminAddressPath)
+			require.Equal(t, tt.expectedArgs, args)
+			require.Equal(t, tt.expectedLogs, logBuf.String())
 		})
 	}
 }

--- a/internal/run/func-e_test.go
+++ b/internal/run/func-e_test.go
@@ -97,7 +97,7 @@ func (f *fakeFuncE) Interrupt(context.Context) error {
 // OnStart creates an admin client using the run directory and waits for Envoy to be ready.
 func (f *fakeFuncE) OnStart(ctx context.Context) (internalapi.AdminClient, error) {
 	// Poll for the admin address path from the Envoy process command line
-	envoyPid, adminAddressPath, err := internaladmin.PollEnvoyPidAndAdminAddressPath(ctx, os.Getpid())
+	envoyPid, adminAddressPath, err := internaladmin.PollEnvoyPidAndAdminAddressPath(ctx, os.Getpid(), f.o.RunID)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/testdata/fake_envoy/main.go
+++ b/internal/testdata/fake_envoy/main.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	"github.com/tetratelabs/func-e/internal"
+	internalapi "github.com/tetratelabs/func-e/internal/api"
 	"github.com/tetratelabs/func-e/internal/envoy/config"
 )
 
@@ -121,6 +122,8 @@ func parseArgs() (adminAddressPath, configPath, configYaml string) {
 	for i := 1; i < len(os.Args); i++ {
 		arg := os.Args[i]
 		switch {
+		case arg == internalapi.ArgsIgnoreRest:
+			return
 		case arg == "run": // Prevent uber bug
 			exit(1, "run -- Couldn't find match for argument")
 		case arg == "-c" || arg == "--config-path":
@@ -262,6 +265,8 @@ func startAdminServer(adminAddress, adminAddressPath string, wg *sync.WaitGroup,
 		exit(1, err.Error())
 	}
 
+	// Envoy writes socket_->connectionInfoProvider().localAddress()->asString()
+	// e.g. 127.0.0.1:9901 for IPv4, [::1]:9901 for IPv6
 	addr := ln.Addr().String()
 	if adminAddressPath != "" {
 		if err := os.WriteFile(adminAddressPath, []byte(addr), 0o600); err != nil {


### PR DESCRIPTION
This integrates `api.RunID()` to disambiguate sub-processes in `NewAdminClient`.

Before, we looked for the first subprocess, which could be anything, such as an ext-proc process. This is a routine use case of built-on-envoy (BOE). Moreover, there's nothing preventing func-e from starting multiple envoys. It was designed to do this. If you can't know which subprocess is envoy or which envoy you are talking about, any AdminClient functionality is thwarted.

To solve this, we add a marker `--run-id` after an `ignore_after` sentinel envoy supports (`--`). This doesn't conflict with envoy args and anyway envoy args precede (`--`). We use `--run-id`, not `--func-e-run-id` both for simplicity and to not brand embedders like ai-gateway as func-e. There's intentionally no config for this to prevent sprawl and also not permanently commit to the marker should we want to change it later.

With this marker in, we have a good idea both what is envoy and what is our envoy. If no-one adds `api.RunID()` it is already stronger than before as we at least scan for the named marker. If they do, it narrows. So, BOE for example, should be safe without even using `api.RunID()` until such time they do like mini-fleet testing or something where multiple envoys are launched.

However, it could be tightened now, with no negative impact:
```go
type Healthcheck struct {
	RunID string `name:"run-id" env:"BOE_RUN_ID" default:"0" hidden:""`
}

func (h *Healthcheck) Run(ctx context.Context) error {
	return healthcheck(ctx, io.Discard, os.Stderr, h.RunID)
}

func doHealthcheck(ctx context.Context, boePid int, runID string, logger *slog.Logger) error {
	adminClient, err := admin.NewAdminClient(ctx, boePid, api.RunID(runID))
	if err != nil {
		logger.Error("Failed to find Envoy admin server", "error", err)
		return err
	}
	return adminClient.IsReady(ctx)
}
```

As usual some cleanupts were warranted. First, even though this function is experimental, it is already coded to multiple projects, so breaking `NewAdminClient` wouldn't be helpful. That's why we accept `options ...api.RunOption`. Even though some are not honored, doing this gives you control of `HTTPTransport` for free, helpful in tests and obs.

Closes #493