### PR TITLE
Use yesterday's envoy main build via the "dev" version

### DIFF
--- a/RATIONALE.md
+++ b/RATIONALE.md
@@ -61,7 +61,22 @@ We also provide `httptest.HTTPClient`, which runs a handler synchronously in
 the caller's goroutine with no I/O at all. Tests who need `*http.Client`, but
 don't need a real server can use this instead.
 
+## Why "dev-latest" instead of a flag?
+
+func-e is embedded in CI systems and tools like [Envoy AI Gateway][ai-gw]
+that may only allow version overrides, not flags. A version string works
+everywhere `ENVOY_VERSION` is accepted, including the Go API.
+
+`dev` installs on demand like all other versions. Once pulled, it stays
+put. This keeps CI runs stable and reproducible without network access on
+every invocation.
+
+`dev-latest` is the explicit refresh trigger. Without it, a cached `dev`
+install would never update. CI pipelines and tools that re-warm caches
+need a way to pull the latest build without manual intervention.
+
 ---
+[ai-gw]: https://github.com/envoyproxy/ai-gateway
 [xdg]: https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html
 [go-work-modfile]: https://go.dev/issue/59996
 [synctest-pkg]: https://pkg.go.dev/testing/synctest

--- a/e2e/func-e_run_test.go
+++ b/e2e/func-e_run_test.go
@@ -44,3 +44,7 @@ func TestRun_CtrlCs(t *testing.T) {
 func TestRun_LegacyHomeDir(t *testing.T) {
 	e2e.TestRunLegacyHomeDir(t.Context(), t, funcEFactory{})
 }
+
+func TestRun_Dev(t *testing.T) {
+	e2e.TestRunDev(t.Context(), t, funcEFactory{})
+}

--- a/e2e/func-e_use_test.go
+++ b/e2e/func-e_use_test.go
@@ -11,6 +11,7 @@ import (
 	"runtime"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
@@ -40,9 +41,34 @@ func TestFuncEUse(t *testing.T) {
 
 	t.Run("already installed", func(t *testing.T) {
 		stdout, stderr, err := funcEExec(t.Context(), "--config-home", configHome, "--data-home", dataHome, "use", version.LastKnownEnvoy.String())
-
 		require.NoError(t, err)
 		require.Equal(t, version.LastKnownEnvoy.String()+" is already downloaded\n", stdout)
+		require.Empty(t, stderr)
+	})
+}
+
+func TestFuncEUse_DevLatest(t *testing.T) {
+	configHome := t.TempDir()
+	dataHome := t.TempDir()
+
+	// Install dev
+	_, _, err := funcEExec(t.Context(), "--config-home", configHome, "--data-home", dataHome, "use", "dev")
+	require.NoError(t, err)
+
+	t.Run("up to date", func(t *testing.T) {
+		stdout, stderr, err := funcEExec(t.Context(), "--config-home", configHome, "--data-home", dataHome, "use", "dev-latest")
+		require.NoError(t, err)
+		require.Empty(t, stdout)
+		require.Empty(t, stderr)
+	})
+
+	t.Run("out of date", func(t *testing.T) {
+		stale := time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC)
+		require.NoError(t, os.Chtimes(filepath.Join(dataHome, "envoy-versions", "dev"), stale, stale))
+
+		stdout, stderr, err := funcEExec(t.Context(), "--config-home", configHome, "--data-home", dataHome, "use", "dev-latest")
+		require.NoError(t, err)
+		require.Regexp(t, `^downloading https:.*tar.*z\r?\n$`, stdout)
 		require.Empty(t, stderr)
 	})
 }

--- a/e2e/main_test.go
+++ b/e2e/main_test.go
@@ -6,20 +6,9 @@ package e2e
 import (
 	"context"
 	"fmt"
-	"io"
-	"net/http"
-	"net/http/httptest"
 	"os"
-	"strings"
 	"testing"
 )
-
-const (
-	envoyVersionsURLEnvKey = "ENVOY_VERSIONS_URL"
-	envoyVersionsJSON      = "envoy-versions.json"
-)
-
-var expectedMockHeaders = map[string]string{"User-Agent": "func-e/dev"}
 
 // TestMain ensures the "func-e" binary is valid.
 func TestMain(m *testing.M) {
@@ -29,19 +18,8 @@ func TestMain(m *testing.M) {
 	}
 
 	// pre-flight check the binary is usable
-	versionLine, _, err := funcEExec(context.Background(), "--version")
-	if err != nil {
+	if _, _, err := funcEExec(context.Background(), "--version"); err != nil {
 		exitOnInvalidBinary(err)
-	}
-
-	// Allow local file override when a SNAPSHOT version
-	if _, err := os.Stat(envoyVersionsJSON); err == nil && strings.Contains(versionLine, "SNAPSHOT") {
-		s, err := mockEnvoyVersionsServer() // no defer s.Close() because os.Exit() subverts it
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "failed to serve %s: %v\n", envoyVersionsJSON, err)
-			os.Exit(1)
-		}
-		os.Setenv(envoyVersionsURLEnvKey, s.URL)
 	}
 	os.Exit(m.Run())
 }
@@ -49,35 +27,4 @@ func TestMain(m *testing.M) {
 func exitOnInvalidBinary(err error) {
 	fmt.Fprintf(os.Stderr, `failed to start e2e tests due to an invalid "func-e" binary: %v\n`, err)
 	os.Exit(1)
-}
-
-// mockEnvoyVersionsServer ensures envoyVersionsURLEnvKey is set appropriately, so that non-release versions can see
-// changes to local envoyVersionsJSON.
-func mockEnvoyVersionsServer() (*httptest.Server, error) {
-	f, err := os.Open(envoyVersionsJSON)
-	if err != nil {
-		return nil, err
-	}
-
-	defer f.Close()
-	b, err := io.ReadAll(f)
-	if err != nil {
-		return nil, err
-	}
-
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		// Ensure e2e tests won't eventually interfere with analytics when run against a release version
-		for k, v := range expectedMockHeaders {
-			h := r.Header.Get(k)
-			if h != v {
-				w.WriteHeader(http.StatusInternalServerError)
-				fmt.Fprintf(w, "invalid %q: %s != %s\n", k, h, v)
-				return
-			}
-		}
-		w.Header().Add("Content-Type", "application/json")
-		w.WriteHeader(http.StatusOK)
-		w.Write(b)
-	}))
-	return ts, nil
 }

--- a/internal/cmd/use.go
+++ b/internal/cmd/use.go
@@ -59,6 +59,9 @@ $ func-e use %s`, currentVersionWorkingDirFile, currentVersionConfigFile, versio
 			if _, err = envoy.InstallIfNeeded(ctx, o); err != nil {
 				return err
 			}
+			if v == version.DevLatest {
+				v = version.Dev
+			}
 			// Persist the input precision. This allows those specifying a MinorVersion to always get the latest patch.
 			return envoy.WriteCurrentVersion(v, o.ConfigHome, o.EnvoyVersionFile())
 		},

--- a/internal/cmd/use_test.go
+++ b/internal/cmd/use_test.go
@@ -4,12 +4,14 @@
 package cmd_test
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
@@ -47,169 +49,106 @@ func TestFuncEUse_VersionValidates(t *testing.T) {
 	}
 }
 
-func TestFuncEUse_InstallsAndWritesHomeVersion(t *testing.T) {
-	o := setupTest(t)
-	evs := o.EnvoyVersion.String()
-
-	c, _, _ := newApp(o)
-	require.NoError(t, c.Run(t.Context(), []string{"func-e", "use", evs}))
-
-	// The binary was installed
-	require.FileExists(t, filepath.Join(o.DataHome, "envoy-versions", evs, "bin", "envoy"+""))
-
-	// The current version was written
-	f, err := os.ReadFile(filepath.Join(o.ConfigHome, "envoy-version"))
-	require.NoError(t, err)
-	require.Equal(t, evs, string(f))
-}
-
-// TODO: everything from here down in this file needs to be rewritten
-func TestFuncEUse_InstallMinorVersion(t *testing.T) {
-	o := setupTest(t)
-
-	type testCase struct {
-		name           string
-		firstVersions  availableVersions
-		secondVersions availableVersions
-		minorVersion   string
+func TestFuncEUse(t *testing.T) {
+	installDev := func(t *testing.T, o *globals.GlobalOpts) {
+		t.Helper()
+		c, _, _ := newApp(o)
+		require.NoError(t, c.Run(t.Context(), []string{"func-e", "use", "dev"}))
+		o.Out = new(bytes.Buffer)
+	}
+	installMinor := func(t *testing.T, o *globals.GlobalOpts, minor string) {
+		t.Helper()
+		c, _, _ := newApp(o)
+		require.NoError(t, c.Run(t.Context(), []string{"func-e", "use", minor}))
+		o.Out = new(bytes.Buffer)
 	}
 
-	tests := []testCase{
+	tests := []struct {
+		name         string
+		setup        func(t *testing.T, o *globals.GlobalOpts)
+		version      string
+		stdout       string
+		savedVersion string
+	}{
+		{name: "patch", version: version.LastKnownEnvoy.String(), stdout: "downloading", savedVersion: version.LastKnownEnvoy.String()},
+		{name: "dev", version: "dev", stdout: "downloading", savedVersion: "dev"},
+		{name: "dev already downloaded", setup: installDev, version: "dev", stdout: "already downloaded", savedVersion: "dev"},
+		{name: "dev-latest up to date", setup: installDev, version: "dev-latest", savedVersion: "dev"},
+		{name: "dev-latest out of date", setup: func(t *testing.T, o *globals.GlobalOpts) {
+			t.Helper()
+			installDev(t, o)
+			stale := time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC)
+			require.NoError(t, os.Chtimes(filepath.Join(o.DataHome, "envoy-versions", "dev"), stale, stale))
+		}, version: "dev-latest", stdout: "downloading", savedVersion: "dev"},
 		{
-			name: "upgradable",
-			firstVersions: availableVersions{
-				latestPatch: "3",
-				versions:    []version.PatchVersion{version.PatchVersion("1.18.3")},
+			name: "minor upgradable",
+			setup: func(t *testing.T, o *globals.GlobalOpts) {
+				t.Helper()
+				overrideAvailableVersions(t, o, []version.PatchVersion{"1.18.3"})
+				installMinor(t, o, "1.18")
+				overrideAvailableVersions(t, o, []version.PatchVersion{"1.18.3", "1.18.4"})
 			},
-			secondVersions: availableVersions{
-				latestPatch: "4",
-				versions:    []version.PatchVersion{version.PatchVersion("1.18.3"), version.PatchVersion("1.18.4")},
-			},
-			minorVersion: "1.18",
+			version: "1.18",
+			stdout:  "downloading",
 		},
 		{
-			name: "not-upgraded",
-			firstVersions: availableVersions{
-				latestPatch: "5",
-				versions:    []version.PatchVersion{version.PatchVersion("1.29.5")},
+			name: "minor not upgraded",
+			setup: func(t *testing.T, o *globals.GlobalOpts) {
+				t.Helper()
+				overrideAvailableVersions(t, o, []version.PatchVersion{"1.29.5"})
+				installMinor(t, o, "1.29")
 			},
-			secondVersions: availableVersions{
-				latestPatch: "5",
-				versions:    []version.PatchVersion{version.PatchVersion("1.29.5")},
+			version: "1.29",
+			stdout:  "already downloaded",
+		},
+		{
+			name: "minor offline after install",
+			setup: func(t *testing.T, o *globals.GlobalOpts) {
+				t.Helper()
+				overrideAvailableVersions(t, o, []version.PatchVersion{"1.29.3"})
+				installMinor(t, o, "1.29")
+				o.GetEnvoyVersions = func(_ context.Context) (*version.ReleaseVersions, error) {
+					return nil, errors.New("offline")
+				}
 			},
-			minorVersion: "1.29",
+			version: "1.29",
+			stdout:  "already downloaded",
 		},
 	}
-
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			var err error
-			o.GetEnvoyVersions, err = newFuncEVersionsTester(t.Context(), o, tc.firstVersions)
-			require.NoError(t, err)
-
-			c, _, _ := newApp(o)
-			require.NoError(t, c.Run(t.Context(), []string{"func-e", "use", tc.minorVersion}))
-			f, err := os.ReadFile(filepath.Join(o.ConfigHome, "envoy-version"))
-			require.NoError(t, err)
-			require.Equal(t, tc.minorVersion, string(f))
-
-			// Set o.EnvoyVersion to empty string so the logic for ensuring installed Envoy version works.
-			o.EnvoyVersion = ""
-			c, stdout, stderr := newApp(o)
-			require.NoError(t, c.Run(t.Context(), []string{"func-e", "which"}))
-			envoyPath := filepath.Join(o.DataHome, "envoy-versions", tc.minorVersion+"."+tc.firstVersions.latestPatch, "bin", "envoy"+"")
-			require.Equal(t, envoyPath+"\n", stdout.String())
-			require.Empty(t, stderr)
-
-			// Update the map returned by Get.
-			o.GetEnvoyVersions, err = newFuncEVersionsTester(t.Context(), o, tc.secondVersions)
-			require.NoError(t, err)
-			c, _, _ = newApp(o)
-			require.NoError(t, c.Run(t.Context(), []string{"func-e", "use", tc.minorVersion}))
-			f, err = os.ReadFile(filepath.Join(o.ConfigHome, "envoy-version"))
-			require.NoError(t, err)
-			require.Equal(t, tc.minorVersion, string(f))
-
-			// Set o.EnvoyVersion to empty string so the logic for ensuring installed Envoy version works.
-			o.EnvoyVersion = ""
-			c, stdout, stderr = newApp(o)
-			require.NoError(t, c.Run(t.Context(), []string{"func-e", "which"}))
-			envoyPath = filepath.Join(o.DataHome, "envoy-versions", tc.minorVersion+"."+tc.secondVersions.latestPatch, "bin", "envoy"+"")
-			require.Equal(t, envoyPath+"\n", stdout.String())
-			require.Empty(t, stderr)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			o := setupTest(t)
+			if tt.setup != nil {
+				tt.setup(t, o)
+			}
+			c, stdout, _ := newApp(o)
+			require.NoError(t, c.Run(t.Context(), []string{"func-e", "use", tt.version}))
+			if tt.stdout != "" {
+				require.Contains(t, stdout.String(), tt.stdout)
+			}
+			if tt.savedVersion != "" {
+				f, err := os.ReadFile(filepath.Join(o.ConfigHome, "envoy-version"))
+				require.NoError(t, err)
+				require.Equal(t, tt.savedVersion, string(f))
+			}
 		})
 	}
 }
 
-func TestFuncEUse_InstallMinorVersionCheckLatestPatchFailed(t *testing.T) {
-	o := setupTest(t)
-
-	// The initial version to be installed.
-	minorVersion := "1.29"
-	latestPatch := "3"
-	initial := availableVersions{
-		latestPatch: latestPatch,
-		versions:    []version.PatchVersion{version.PatchVersion(minorVersion + "." + latestPatch)},
-	}
-
-	var err error
-	o.GetEnvoyVersions, err = newFuncEVersionsTester(t.Context(), o, initial)
+func overrideAvailableVersions(t *testing.T, o *globals.GlobalOpts, patches []version.PatchVersion) {
+	t.Helper()
+	evs, err := envoy.NewGetVersions(o.HTTPClient, o.EnvoyVersionsURL, o.UserAgent)(t.Context())
 	require.NoError(t, err)
-
-	c, _, _ := newApp(o)
-	require.NoError(t, c.Run(t.Context(), []string{"func-e", "use", minorVersion}))
-	f, err := os.ReadFile(filepath.Join(o.ConfigHome, "envoy-version"))
-	require.NoError(t, err)
-	require.Equal(t, minorVersion, string(f))
-
-	o.EnvoyVersion = ""
-	c, stdout, stderr := newApp(o)
-	require.NoError(t, c.Run(t.Context(), []string{"func-e", "which"}))
-	envoyPath := filepath.Join(o.DataHome, "envoy-versions", minorVersion+"."+latestPatch, "bin", "envoy"+"")
-	require.Equal(t, envoyPath+"\n", stdout.String())
-	require.Empty(t, stderr)
-
-	o.GetEnvoyVersions = func(_ context.Context) (*version.ReleaseVersions, error) {
-		return nil, errors.New("ice cream")
-	}
-	c, _, _ = newApp(o)
-	require.NoError(t, c.Run(t.Context(), []string{"func-e", "use", minorVersion}))
-	f, err = os.ReadFile(filepath.Join(o.ConfigHome, "envoy-version"))
-	require.NoError(t, err)
-	require.Equal(t, minorVersion, string(f))
-
-	o.EnvoyVersion = ""
-	c, stdout, stderr = newApp(o)
-	require.NoError(t, c.Run(t.Context(), []string{"func-e", "which"}))
-	// The path points to the latest installed version.
-	envoyPath = filepath.Join(o.DataHome, "envoy-versions", minorVersion+"."+latestPatch, "bin", "envoy"+"")
-	t.Log(stdout.String())
-	require.Equal(t, envoyPath+"\n", stdout.String())
-	require.Empty(t, stderr)
-}
-
-type availableVersions struct {
-	latestPatch string
-	versions    []version.PatchVersion
-}
-
-func newFuncEVersionsTester(ctx context.Context, o *globals.GlobalOpts, av availableVersions) (version.GetReleaseVersions, error) {
-	feV := envoy.NewGetVersions(o.HTTPClient, o.EnvoyVersionsURL, o.UserAgent)
-	ev, err := feV(ctx)
-	if err != nil {
-		return nil, err
-	}
-	// Copy versions releases from the setupTest and append more versions for testing.
-	copied := ev
-	var m version.Release
-	for _, entry := range ev.Versions {
-		m = entry
+	var base version.Release
+	for _, r := range evs.Versions {
+		base = r
 		break
 	}
-	for _, v := range av.versions {
-		copied.Versions[v] = m
+	versions := make(map[version.PatchVersion]version.Release, len(patches))
+	for _, p := range patches {
+		versions[p] = base
 	}
-	return func(_ context.Context) (*version.ReleaseVersions, error) {
-		return copied, nil
-	}, nil
+	o.GetEnvoyVersions = func(_ context.Context) (*version.ReleaseVersions, error) {
+		return &version.ReleaseVersions{Versions: versions, SHA256Sums: evs.SHA256Sums, Dev: evs.Dev}, nil
+	}
 }

--- a/internal/cmd/versions.go
+++ b/internal/cmd/versions.go
@@ -42,11 +42,19 @@ func NewVersionsCmd(o *globals.GlobalOpts) *cli.Command {
 				return err
 			}
 
+			var dev *version.DevRelease
 			if c.Bool("all") {
-				if evs, err := o.GetEnvoyVersions(ctx); err != nil {
+				evs, err := o.GetEnvoyVersions(ctx)
+				if err != nil {
 					return err
-				} else if err := addAvailableVersions(&rows, evs.Versions, o.Platform); err != nil {
+				}
+				if err := addAvailableVersions(&rows, evs.Versions, o.Platform); err != nil {
 					return err
+				}
+				if evs.Dev != nil {
+					if _, ok := evs.Dev.Tarballs[o.Platform]; ok {
+						dev = evs.Dev
+					}
 				}
 			}
 
@@ -60,6 +68,9 @@ func NewVersionsCmd(o *globals.GlobalOpts) *cli.Command {
 
 			// We use a tab writer to ensure we can format the current version
 			w := tabwriter.NewWriter(c.Root().Writer, 0, 0, 1, ' ', tabwriter.AlignRight)
+			if dev != nil {
+				_, _ = fmt.Fprintf(w, "  dev %s (%s)\n", dev.ReleaseDate, dev.CommitSha[:8])
+			}
 			for _, vr := range rows { //nolint:gocritic
 				// TODO: handle when currentVersion is a MinorVersion
 				pv, ok := currentVersion.(version.PatchVersion)

--- a/internal/cmd/versions_cmd_test.go
+++ b/internal/cmd/versions_cmd_test.go
@@ -4,6 +4,7 @@
 package cmd_test
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -16,140 +17,131 @@ import (
 	"github.com/tetratelabs/func-e/internal/version"
 )
 
-func TestFuncEVersions_NothingYet(t *testing.T) {
-	o := setupTest(t)
-
-	c, stdout, stderr := newApp(o)
-	err := c.Run(t.Context(), []string{"func-e", "versions"})
-
-	require.NoError(t, err)
-	require.Empty(t, stdout) // allows consistent parsing even when nothing yet installed
-	require.Empty(t, stderr)
-}
-
-func TestFuncEVersions_NoCurrentVersion(t *testing.T) {
-	o := setupTestVersions(t)
-	require.NoError(t, os.Remove(filepath.Join(o.ConfigHome, "envoy-version")))
-
-	c, stdout, stderr := newApp(o)
-	err := c.Run(t.Context(), []string{"func-e", "versions"})
-
-	require.NoError(t, err)
-	require.Equal(t, `  1.2.2 2021-01-31
-  1.1.2 2021-01-31
-  1.2.1 2021-01-30
-`, stdout.String())
-	require.Empty(t, stderr)
-}
-
-// TestFuncEVersions_CurrentVersion tests depend on prior state, so execute sequentially. This doesn't use a matrix
-// to improve readability
-func TestFuncEVersions_CurrentVersion(t *testing.T) {
-	o := setupTestVersions(t)
-
-	t.Run("no current version", func(t *testing.T) {
-		require.NoError(t, os.Remove(filepath.Join(o.ConfigHome, "envoy-version")))
-
-		c, stdout, _ := newApp(o)
-		require.NoError(t, c.Run(t.Context(), []string{"func-e", "versions"}))
-		require.Equal(t, `  1.2.2 2021-01-31
-  1.1.2 2021-01-31
-  1.2.1 2021-01-30
-`, stdout.String())
-	})
-
-	t.Run("set by $FUNC_E_CONFIG_HOME/envoy-version", func(t *testing.T) {
-		require.NoError(t, os.WriteFile(filepath.Join(o.ConfigHome, "envoy-version"), []byte("1.1.2"), 0o600))
-
-		c, stdout, _ := newApp(o)
-		require.NoError(t, c.Run(t.Context(), []string{"func-e", "versions"}))
-		require.Equal(t, `  1.2.2 2021-01-31
-* 1.1.2 2021-01-31 (set by $FUNC_E_CONFIG_HOME/envoy-version)
-  1.2.1 2021-01-30
-`, stdout.String())
-	})
-
-	t.Run("set by $PWD/.envoy-version", func(t *testing.T) {
-		t.Chdir(t.TempDir())
-		require.NoError(t, os.WriteFile(".envoy-version", []byte("1.2.2"), 0o600))
-
-		c, stdout, _ := newApp(o)
-		require.NoError(t, c.Run(t.Context(), []string{"func-e", "versions"}))
-		require.Equal(t, `* 1.2.2 2021-01-31 (set by $PWD/.envoy-version)
-  1.1.2 2021-01-31
-  1.2.1 2021-01-30
-`, stdout.String())
-	})
-
-	t.Run("set by $ENVOY_VERSION", func(t *testing.T) {
-		t.Setenv("ENVOY_VERSION", "1.2.1")
-
-		c, stdout, _ := newApp(o)
-		require.NoError(t, c.Run(t.Context(), []string{"func-e", "versions"}))
-		require.Equal(t, `  1.2.2 2021-01-31
-  1.1.2 2021-01-31
-* 1.2.1 2021-01-30 (set by $ENVOY_VERSION)
-`, stdout.String())
-	})
-}
-
-func TestFuncEVersions_Sorted(t *testing.T) {
-	o := setupTestVersions(t)
-
-	c, stdout, stderr := newApp(o)
-	err := c.Run(t.Context(), []string{"func-e", "versions"})
-
-	require.NoError(t, err)
-	require.Equal(t, `  1.2.2 2021-01-31
-  1.1.2 2021-01-31
-* 1.2.1 2021-01-30 (set by $FUNC_E_CONFIG_HOME/envoy-version)
-`, stdout.String())
-	require.Empty(t, stderr)
-}
-
-func TestFuncEVersions_All_OnlyRemote(t *testing.T) {
-	o := setupTest(t)
-
-	c, stdout, stderr := newApp(o)
-	err := c.Run(t.Context(), []string{"func-e", "versions", "-a"})
-
-	require.NoError(t, err)
-	require.Equal(t, fmt.Sprintf("  %s 2020-12-31\n", version.LastKnownEnvoy), stdout.String())
-	require.Empty(t, stderr)
-}
-
-func TestFuncEVersions_All_RemoteIsCurrent(t *testing.T) {
-	o := setupTest(t)
-
-	v := version.LastKnownEnvoy.String()
-	versionDir := filepath.Join(o.DataHome, "envoy-versions", v)
-	require.NoError(t, os.MkdirAll(versionDir, 0o700))
-	morerequire.RequireSetMtime(t, versionDir, "2020-12-31")
-	require.NoError(t, os.WriteFile(filepath.Join(o.ConfigHome, "envoy-version"), []byte(v), 0o600))
-
-	expected := fmt.Sprintf("* %s 2020-12-31 (set by $FUNC_E_CONFIG_HOME/envoy-version)\n", v)
-
-	c, stdout, stderr := newApp(o)
-	err := c.Run(t.Context(), []string{"func-e", "versions", "-a"})
-
-	require.NoError(t, err)
-	require.Equal(t, expected, stdout.String())
-	require.Empty(t, stderr)
-}
-
-func TestFuncEVersions_All_Mixed(t *testing.T) {
-	o := setupTestVersions(t)
-
-	c, stdout, stderr := newApp(o)
-	err := c.Run(t.Context(), []string{"func-e", "versions", "-a"})
-
-	require.NoError(t, err)
-	require.Equal(t, fmt.Sprintf(`  1.2.2 2021-01-31
-  1.1.2 2021-01-31
-* 1.2.1 2021-01-30 (set by $FUNC_E_CONFIG_HOME/envoy-version)
-  %s 2020-12-31
-`, version.LastKnownEnvoy), stdout.String())
-	require.Empty(t, stderr)
+func TestFuncEVersions(t *testing.T) {
+	tests := []struct {
+		name     string
+		args     []string
+		setup    func(t *testing.T) *globals.GlobalOpts
+		expected string
+	}{
+		{
+			name:     "nothing installed",
+			args:     []string{"func-e", "versions"},
+			setup:    setupTest,
+			expected: "",
+		},
+		{
+			name: "no current version",
+			args: []string{"func-e", "versions"},
+			setup: func(t *testing.T) *globals.GlobalOpts {
+				t.Helper()
+				o := setupTestVersions(t)
+				require.NoError(t, os.Remove(filepath.Join(o.ConfigHome, "envoy-version")))
+				return o
+			},
+			expected: "  1.2.2 2021-01-31\n  1.1.2 2021-01-31\n  1.2.1 2021-01-30\n",
+		},
+		{
+			name:     "sorted with current",
+			args:     []string{"func-e", "versions"},
+			setup:    setupTestVersions,
+			expected: "  1.2.2 2021-01-31\n  1.1.2 2021-01-31\n* 1.2.1 2021-01-30 (set by $FUNC_E_CONFIG_HOME/envoy-version)\n",
+		},
+		{
+			name: "current set by config",
+			args: []string{"func-e", "versions"},
+			setup: func(t *testing.T) *globals.GlobalOpts {
+				t.Helper()
+				o := setupTestVersions(t)
+				require.NoError(t, os.WriteFile(filepath.Join(o.ConfigHome, "envoy-version"), []byte("1.1.2"), 0o600))
+				return o
+			},
+			expected: "  1.2.2 2021-01-31\n* 1.1.2 2021-01-31 (set by $FUNC_E_CONFIG_HOME/envoy-version)\n  1.2.1 2021-01-30\n",
+		},
+		{
+			name: "current set by PWD",
+			args: []string{"func-e", "versions"},
+			setup: func(t *testing.T) *globals.GlobalOpts {
+				t.Helper()
+				o := setupTestVersions(t)
+				t.Chdir(t.TempDir())
+				require.NoError(t, os.WriteFile(".envoy-version", []byte("1.2.2"), 0o600))
+				return o
+			},
+			expected: "* 1.2.2 2021-01-31 (set by $PWD/.envoy-version)\n  1.1.2 2021-01-31\n  1.2.1 2021-01-30\n",
+		},
+		{
+			name: "current set by ENVOY_VERSION",
+			args: []string{"func-e", "versions"},
+			setup: func(t *testing.T) *globals.GlobalOpts {
+				t.Helper()
+				o := setupTestVersions(t)
+				t.Setenv("ENVOY_VERSION", "1.2.1")
+				return o
+			},
+			expected: "  1.2.2 2021-01-31\n  1.1.2 2021-01-31\n* 1.2.1 2021-01-30 (set by $ENVOY_VERSION)\n",
+		},
+		{
+			name:     "all only remote",
+			args:     []string{"func-e", "versions", "-a"},
+			setup:    setupTest,
+			expected: fmt.Sprintf("  dev 2020-12-31 (92c6cb58)\n  %s 2020-12-31\n", version.LastKnownEnvoy),
+		},
+		{
+			name: "all remote is current",
+			args: []string{"func-e", "versions", "-a"},
+			setup: func(t *testing.T) *globals.GlobalOpts {
+				t.Helper()
+				o := setupTest(t)
+				v := version.LastKnownEnvoy.String()
+				versionDir := filepath.Join(o.DataHome, "envoy-versions", v)
+				require.NoError(t, os.MkdirAll(versionDir, 0o700))
+				morerequire.RequireSetMtime(t, versionDir, "2020-12-31")
+				require.NoError(t, os.WriteFile(filepath.Join(o.ConfigHome, "envoy-version"), []byte(v), 0o600))
+				return o
+			},
+			expected: fmt.Sprintf("  dev 2020-12-31 (92c6cb58)\n* %s 2020-12-31 (set by $FUNC_E_CONFIG_HOME/envoy-version)\n", version.LastKnownEnvoy),
+		},
+		{
+			name: "all no dev in JSON",
+			args: []string{"func-e", "versions", "-a"},
+			setup: func(t *testing.T) *globals.GlobalOpts {
+				t.Helper()
+				o := setupTest(t)
+				o.GetEnvoyVersions = func(_ context.Context) (*version.ReleaseVersions, error) {
+					return &version.ReleaseVersions{
+						Versions: map[version.PatchVersion]version.Release{
+							version.LastKnownEnvoy: {
+								ReleaseDate: "2020-12-31",
+								Tarballs: map[version.Platform]version.TarballURL{
+									o.Platform: "https://example.com/envoy.tar.gz",
+								},
+							},
+						},
+						SHA256Sums: map[version.Tarball]version.SHA256Sum{},
+					}, nil
+				}
+				return o
+			},
+			expected: fmt.Sprintf("  %s 2020-12-31\n", version.LastKnownEnvoy),
+		},
+		{
+			name:  "all mixed local and remote",
+			args:  []string{"func-e", "versions", "-a"},
+			setup: setupTestVersions,
+			expected: fmt.Sprintf("  dev 2020-12-31 (92c6cb58)\n  1.2.2 2021-01-31\n  1.1.2 2021-01-31\n* 1.2.1 2021-01-30 (set by $FUNC_E_CONFIG_HOME/envoy-version)\n  %s 2020-12-31\n",
+				version.LastKnownEnvoy),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			o := tt.setup(t)
+			c, stdout, stderr := newApp(o)
+			require.NoError(t, c.Run(t.Context(), tt.args))
+			require.Equal(t, tt.expected, stdout.String())
+			require.Empty(t, stderr)
+		})
+	}
 }
 
 func setupTestVersions(t *testing.T) (o *globals.GlobalOpts) {

--- a/internal/envoy/install.go
+++ b/internal/envoy/install.go
@@ -22,19 +22,53 @@ var binEnvoy = filepath.Join("bin", "envoy")
 // InstallIfNeeded downloads an Envoy binary corresponding to globals.GlobalOpts and returns a path to it or an error.
 func InstallIfNeeded(ctx context.Context, o *globals.GlobalOpts) (string, error) {
 	v := o.EnvoyVersion
+	devLatest := v == version.DevLatest
+	if devLatest {
+		v = version.Dev
+	}
 	installPath := filepath.Join(o.EnvoyVersionsDir(), v.String())
 	envoyPath := filepath.Join(installPath, binEnvoy)
 	_, err := os.Stat(envoyPath)
-	switch {
-	case os.IsNotExist(err):
-		var evs *version.ReleaseVersions // Get version metadata for what we will install
+
+	var evs *version.ReleaseVersions // Get version metadata for what we will install
+
+	if devLatest && err == nil {
 		evs, err = o.GetEnvoyVersions(ctx)
 		if err != nil {
 			return "", err
 		}
+		if evs.Dev != nil { // Skip re-download if the local install matches the remote release date
+			remoteMtime, parseErr := time.Parse("2006-01-02", string(evs.Dev.ReleaseDate))
+			stat, statErr := os.Stat(installPath)
+			if parseErr == nil && statErr == nil && stat.ModTime().UTC().Truncate(24*time.Hour).Equal(remoteMtime) {
+				return verifyEnvoy(installPath)
+			}
+		}
+		err = os.ErrNotExist // force the download branch
+	}
 
-		tarballURL := evs.Versions[v].Tarballs[o.Platform] // Ensure there is a version for this platform
-		if tarballURL == "" {
+	switch {
+	case os.IsNotExist(err):
+		if evs == nil {
+			evs, err = o.GetEnvoyVersions(ctx)
+			if err != nil {
+				return "", err
+			}
+		}
+
+		var tarballURL version.TarballURL
+		var releaseDate version.ReleaseDate
+		if v == version.Dev {
+			if evs.Dev != nil {
+				tarballURL = evs.Dev.Tarballs[o.Platform]
+				releaseDate = evs.Dev.ReleaseDate
+			}
+		} else {
+			r := evs.Versions[v]
+			tarballURL = r.Tarballs[o.Platform]
+			releaseDate = r.ReleaseDate
+		}
+		if tarballURL == "" { // Ensure there is a version for this platform
 			return "", fmt.Errorf("couldn't find version %q for platform %q", v, o.Platform)
 		}
 
@@ -45,7 +79,7 @@ func InstallIfNeeded(ctx context.Context, o *globals.GlobalOpts) (string, error)
 		}
 
 		var mtime time.Time // Create a directory for the version, preserving the release date as its mtime
-		if mtime, err = time.Parse("2006-01-02", string(evs.Versions[v].ReleaseDate)); err != nil {
+		if mtime, err = time.Parse("2006-01-02", string(releaseDate)); err != nil {
 			return "", fmt.Errorf("couldn't find releaseDate of version %q for platform %q: %w", v, o.Platform, err)
 		}
 		if err = os.MkdirAll(installPath, 0o750); err != nil {

--- a/internal/envoy/install_test.go
+++ b/internal/envoy/install_test.go
@@ -13,6 +13,7 @@ import (
 	"runtime"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
@@ -98,7 +99,7 @@ func TestUntarEnvoy(t *testing.T) {
 }
 
 func TestInstallIfNeeded_ErrorOnIncorrectURL(t *testing.T) {
-	o := setupInstallTest(t)
+	o := setupInstallTest(t, version.LastKnownEnvoy)
 
 	o.EnvoyVersionsURL += "/varsionz.json"
 	o.GetEnvoyVersions = NewGetVersions(o.HTTPClient, o.EnvoyVersionsURL, o.UserAgent)
@@ -132,7 +133,7 @@ func TestInstallIfNeeded_Validates(t *testing.T) {
 	for _, tt := range tests {
 		tc := tt
 		t.Run(tc.name, func(t *testing.T) {
-			o := setupInstallTest(t)
+			o := setupInstallTest(t, version.LastKnownEnvoy)
 			o.Platform = tc.p
 			o.Out = new(bytes.Buffer)
 			o.EnvoyVersion = tc.v
@@ -144,41 +145,69 @@ func TestInstallIfNeeded_Validates(t *testing.T) {
 }
 
 func TestInstallIfNeeded(t *testing.T) {
-	o := setupInstallTest(t)
+	installDev := func(t *testing.T, o *installTest) {
+		t.Helper()
+		o.EnvoyVersion = version.Dev
+		_, err := InstallIfNeeded(o.ctx, &o.GlobalOpts)
+		require.NoError(t, err)
+		o.Out = new(bytes.Buffer)
+	}
 
-	o.EnvoyVersion = version.LastKnownEnvoy
-	envoyPath, e := InstallIfNeeded(o.ctx, &o.GlobalOpts)
-	require.NoError(t, e)
-	require.Equal(t, o.EnvoyPath, envoyPath)
-	require.FileExists(t, envoyPath)
-
-	versionDir := filepath.Dir(filepath.Dir(envoyPath))
-	f, err := os.Stat(versionDir)
-	require.NoError(t, err)
-	require.Equal(t, f.ModTime().UTC().Format("2006-01-02"), string(test.FakeReleaseDate))
-
-	require.Equal(t, fmt.Sprintf("downloading %s\n", o.tarballURL), o.Out.(*bytes.Buffer).String())
-}
-
-func TestInstallIfNeeded_AlreadyExists(t *testing.T) {
-	o := setupInstallTest(t)
-
-	require.NoError(t, os.MkdirAll(filepath.Dir(o.EnvoyPath), 0o700))
-	require.NoError(t, os.WriteFile(o.EnvoyPath, []byte("fake"), 0o700))
-
-	envoyStat, err := os.Stat(o.EnvoyPath)
-	require.NoError(t, err)
-
-	o.EnvoyVersion = version.LastKnownEnvoy
-	envoyPath, e := InstallIfNeeded(o.ctx, &o.GlobalOpts)
-	require.NoError(t, e)
-	require.Equal(t, fmt.Sprintf("%s is already downloaded\n", version.LastKnownEnvoy), o.Out.(*bytes.Buffer).String())
-
-	newStat, e := os.Stat(envoyPath)
-	require.NoError(t, e)
-
-	// didn't overwrite
-	require.Equal(t, envoyStat, newStat)
+	tests := []struct {
+		name        string
+		setupV      version.PatchVersion
+		setup       func(t *testing.T, o *installTest)
+		version     version.PatchVersion
+		stdout      string
+		expectedErr string
+	}{
+		{name: "release", setupV: version.LastKnownEnvoy, version: version.LastKnownEnvoy, stdout: "downloading"},
+		{name: "dev", setupV: version.Dev, version: version.Dev, stdout: "downloading"},
+		{name: "already exists", setupV: version.LastKnownEnvoy, setup: func(t *testing.T, o *installTest) {
+			t.Helper()
+			require.NoError(t, os.MkdirAll(filepath.Dir(o.EnvoyPath), 0o700))
+			require.NoError(t, os.WriteFile(o.EnvoyPath, []byte("fake"), 0o700))
+		}, version: version.LastKnownEnvoy, stdout: "already downloaded"},
+		{name: "dev-latest up to date", setupV: version.Dev, setup: installDev, version: version.DevLatest},
+		{name: "dev-latest stale", setupV: version.Dev, setup: func(t *testing.T, o *installTest) {
+			t.Helper()
+			installDev(t, o)
+			stale := time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC)
+			require.NoError(t, os.Chtimes(filepath.Join(o.EnvoyVersionsDir(), "dev"), stale, stale))
+		}, version: version.DevLatest, stdout: "downloading"},
+		{name: "dev wrong platform", setupV: version.Dev, setup: func(t *testing.T, o *installTest) {
+			t.Helper()
+			o.Platform = "windows/amd64"
+		}, version: version.Dev, expectedErr: `couldn't find version "dev" for platform "windows/amd64"`},
+		{name: "dev missing from JSON", setupV: version.Dev, setup: func(t *testing.T, o *installTest) {
+			t.Helper()
+			o.GetEnvoyVersions = func(_ context.Context) (*version.ReleaseVersions, error) {
+				return &version.ReleaseVersions{
+					Versions:   map[version.PatchVersion]version.Release{},
+					SHA256Sums: map[version.Tarball]version.SHA256Sum{},
+				}, nil
+			}
+		}, version: version.Dev, expectedErr: fmt.Sprintf(`couldn't find version "dev" for platform %q`, globals.DefaultPlatform)},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			o := setupInstallTest(t, tt.setupV)
+			if tt.setup != nil {
+				tt.setup(t, o)
+			}
+			o.EnvoyVersion = tt.version
+			envoyPath, err := InstallIfNeeded(o.ctx, &o.GlobalOpts)
+			if tt.expectedErr != "" {
+				require.EqualError(t, err, tt.expectedErr)
+				return
+			}
+			require.NoError(t, err)
+			require.FileExists(t, envoyPath)
+			if tt.stdout != "" {
+				require.Contains(t, o.Out.(*bytes.Buffer).String(), tt.stdout)
+			}
+		})
+	}
 }
 
 func TestVerifyEnvoy(t *testing.T) {
@@ -215,15 +244,16 @@ type installTest struct {
 	tarballURL version.TarballURL
 }
 
-func setupInstallTest(t *testing.T) *installTest {
+func setupInstallTest(t *testing.T, v version.PatchVersion) *installTest {
 	t.Helper()
 	baseURL := "http://" + admin.ServerAddr
 	handler := test.NewEnvoyVersionsHandler(t, baseURL, version.LastKnownEnvoy)
 	homeDir := t.TempDir()
+
 	setup := &installTest{
 		ctx:        t.Context(),
 		tempDir:    t.TempDir(),
-		tarballURL: test.TarballURL(baseURL, runtime.GOOS, runtime.GOARCH, version.LastKnownEnvoy),
+		tarballURL: test.TarballURL(baseURL, runtime.GOOS, runtime.GOARCH, v),
 		GlobalOpts: globals.GlobalOpts{
 			ConfigHome:       homeDir,
 			DataHome:         homeDir,
@@ -233,7 +263,7 @@ func setupInstallTest(t *testing.T) *installTest {
 			Out:              new(bytes.Buffer),
 			Platform:         globals.DefaultPlatform,
 			RunOpts: globals.RunOpts{
-				EnvoyPath:  filepath.Join(homeDir, "envoy-versions", version.LastKnownEnvoy.String(), binEnvoy),
+				EnvoyPath:  filepath.Join(homeDir, "envoy-versions", v.String(), binEnvoy),
 				HTTPClient: httptest.HTTPClient(handler),
 			},
 		},

--- a/internal/run/func-e_run_test.go
+++ b/internal/run/func-e_run_test.go
@@ -47,3 +47,7 @@ func TestRun_LegacyHomeDir(t *testing.T) {
 	t.Setenv("FUNC_E_HOME", homeDir)
 	e2e.TestRunLegacyHomeDir(t.Context(), t, fakeFuncEFactory{})
 }
+
+func TestRun_Dev(t *testing.T) {
+	e2e.TestRunDev(t.Context(), t, fakeFuncEFactory{})
+}

--- a/internal/test/e2e/testrun.go
+++ b/internal/test/e2e/testrun.go
@@ -228,6 +228,19 @@ func TestRunLegacyHomeDir(ctx context.Context, t *testing.T, factory FuncEFactor
 	})
 }
 
+// TestRunDev tests "func-e run" resolves and runs a dev build.
+func TestRunDev(ctx context.Context, t *testing.T, factory FuncEFactory) {
+	t.Setenv("ENVOY_VERSION", "dev")
+	executeRunTest(ctx, t, factory, RunTestOptions{
+		Args: []string{"--config-yaml", "admin: {address: {socket_address: {address: '127.0.0.1', port_value: 0}}}"},
+		TestFunc: func(ctx context.Context, _ func(context.Context) error, adminClient internalapi.AdminClient) {
+			info, err := adminClient.Get(ctx, "/server_info")
+			require.NoError(t, err)
+			require.Contains(t, string(info), "-dev")
+		},
+	})
+}
+
 // setupTestFiles writes the given files to the current directory for test setup.
 func setupTestFiles(t *testing.T, files map[string][]byte) {
 	t.Helper()

--- a/internal/test/server.go
+++ b/internal/test/server.go
@@ -27,7 +27,8 @@ import (
 
 const (
 	// FakeReleaseDate helps us make sure main code doesn't accidentally write the system time instead of the expected.
-	FakeReleaseDate = version.ReleaseDate("2020-12-31")
+	FakeReleaseDate  = version.ReleaseDate("2020-12-31")
+	FakeDevCommitSha = "92c6cb5831fc0faccbf6707bfc156458d5c5932f"
 	// Even though currently binaries are compressed with "xz" more than "gz", using "gz" in tests allows us to re-use
 	// tar.TarGz instead of complicating internal utilities or adding dependencies only for tests.
 	archiveFormat = ".tar.gz"
@@ -78,11 +79,22 @@ func (s *server) init(baseURL string, v version.PatchVersion) {
 				version.Platform("linux" + "/" + runtime.GOARCH):  TarballURL(baseURL, "linux", runtime.GOARCH, v),
 				version.Platform("darwin" + "/" + runtime.GOARCH): TarballURL(baseURL, "darwin", runtime.GOARCH, v),
 			}}},
+		Dev: &version.DevRelease{
+			ReleaseDate: FakeReleaseDate,
+			CommitSha:   FakeDevCommitSha,
+			Tarballs: map[version.Platform]version.TarballURL{
+				version.Platform("linux/" + runtime.GOARCH):  TarballURL(baseURL, "linux", runtime.GOARCH, version.Dev),
+				version.Platform("darwin/" + runtime.GOARCH): TarballURL(baseURL, "darwin", runtime.GOARCH, version.Dev),
+			},
+		},
 		SHA256Sums: map[version.Tarball]version.SHA256Sum{},
 	}
 	fakeEnvoyTarGz, sha256Sum := RequireFakeEnvoyTarGz(s.t, v)
 	s.fakeEnvoyTarGz = fakeEnvoyTarGz
 	for _, u := range s.versions.Versions[v].Tarballs {
+		s.versions.SHA256Sums[version.Tarball(path.Base(string(u)))] = sha256Sum
+	}
+	for _, u := range s.versions.Dev.Tarballs {
 		s.versions.SHA256Sums[version.Tarball(path.Base(string(u)))] = sha256Sum
 	}
 	versionsJSON, err := json.Marshal(s.versions)
@@ -103,7 +115,7 @@ func (s *server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		}
 
 		v := strings.Split(subpath, "/")[0]
-		if version.NewPatchVersion(v) == "" {
+		if v != "dev" && version.NewPatchVersion(v) == "" {
 			w.WriteHeader(http.StatusNotFound)
 			return
 		}

--- a/internal/testdata/fake_envoy/main.go
+++ b/internal/testdata/fake_envoy/main.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/tetratelabs/func-e/internal"
 	"github.com/tetratelabs/func-e/internal/envoy/config"
+	"github.com/tetratelabs/func-e/internal/version"
 )
 
 const (
@@ -333,21 +334,34 @@ func adminEndpoints(w http.ResponseWriter, r *http.Request) {
 		// Support query parameters like ?include_eds
 		// Check if include_eds is present as a query parameter (with or without value)
 		if _, ok := r.URL.Query()["include_eds"]; ok {
-			_, _ = w.Write([]byte(`{"configs": [{"@type": "type.googleapis.com/envoy.admin.v3.EndpointsConfigDump"}]}`))
+			w.Write([]byte(`{"configs": [{"@type": "type.googleapis.com/envoy.admin.v3.EndpointsConfigDump"}]}`))
 		} else {
-			_, _ = w.Write([]byte(`{"configs": []}`))
+			w.Write([]byte(`{"configs": []}`))
 		}
 	case "/ready":
 		w.Header().Set("Content-Type", "text/plain; charset=UTF-8")
 		w.WriteHeader(http.StatusOK)
-		_, _ = w.Write([]byte("LIVE" + lf))
+		w.Write([]byte("LIVE" + lf))
 	case "/listeners":
 		w.Header().Set("Content-Type", "application/json; charset=UTF-8")
 		w.WriteHeader(http.StatusOK)
 		b, _ := json.Marshal(struct {
 			ListenerStatuses []listenerStatus `json:"listener_statuses"`
 		}{ListenerStatuses: listenerStatuses})
-		_, _ = w.Write(b)
+		w.Write(b)
+	case "/server_info":
+		v := version.LastKnownEnvoy.String()
+		if os.Getenv("ENVOY_VERSION") == "dev" {
+			v += "-dev"
+		}
+		w.Header().Set("Content-Type", "application/json; charset=UTF-8")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprintf(w, `{
+ "version": "cafebabecafebabecafebabecafebabecafebabe/%s/Clean/RELEASE/BoringSSL",
+ "state": "LIVE",
+ "hot_restart_version": "disabled"
+}
+`, v)
 	default:
 		w.WriteHeader(http.StatusNotFound)
 	}
@@ -362,7 +376,7 @@ func accessLogHandler(w http.ResponseWriter, r *http.Request) {
 	// status code will be.
 	response := []byte("Hello, World!")
 	w.WriteHeader(http.StatusOK)
-	_, _ = w.Write(response)
+	w.Write(response)
 
 	duration := time.Since(startTime).Milliseconds()
 	fprintf(os.Stdout, "[%s] \"%s %s %s\" %d - 0 %d %dms - \"-\" \"%s\" \"-\" \"%s\" \"-\"%s",
@@ -384,11 +398,11 @@ func staticFileHandler(w http.ResponseWriter, r *http.Request) {
 		data, err := os.ReadFile("response.txt")
 		if err != nil {
 			w.WriteHeader(http.StatusInternalServerError)
-			_, _ = w.Write([]byte("error: " + err.Error()))
+			w.Write([]byte("error: " + err.Error()))
 			return
 		}
 		w.WriteHeader(http.StatusOK)
-		_, _ = w.Write(data)
+		w.Write(data)
 	} else {
 		w.WriteHeader(http.StatusNotFound)
 	}

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -66,10 +66,22 @@ func NewPatchVersion(input string) PatchVersion {
 	return ""
 }
 
+// Dev is the version string for dev builds.
+const Dev = PatchVersion("dev")
+
+// DevLatest is a pseudo-version that always refreshes the dev cache.
+const DevLatest = PatchVersion("dev-latest")
+
 // NewVersion returns a valid input or an error
 func NewVersion(tag, input string) (Version, error) {
 	if input == "" {
 		return nil, fmt.Errorf("missing %s", tag)
+	}
+	if input == "dev" {
+		return Dev, nil
+	}
+	if input == "dev-latest" {
+		return DevLatest, nil
 	}
 	if pv := NewPatchVersion(input); pv != "" {
 		return pv, nil
@@ -159,6 +171,15 @@ type ReleaseVersions struct {
 	Versions map[PatchVersion]Release `json:"versions"`
 	// SHA256Sums maps a Tarball to its SHA256Sum
 	SHA256Sums map[Tarball]SHA256Sum `json:"sha256sums"`
+	// Dev is the dev build, if present in the versions JSON
+	Dev *DevRelease `json:"dev,omitempty"`
+}
+
+// DevRelease describes a dev build
+type DevRelease struct {
+	ReleaseDate ReleaseDate             `json:"releaseDate"`
+	CommitSha   string                  `json:"commitSha"`
+	Tarballs    map[Platform]TarballURL `json:"tarballs,omitempty"`
 }
 
 // Platform encodes 'runtime.GOOS/runtime.GOARCH'. Ex "darwin/amd64"

--- a/internal/version/version_test.go
+++ b/internal/version/version_test.go
@@ -4,11 +4,41 @@
 package version
 
 import (
+	"encoding/json"
 	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 )
+
+func TestReleaseVersions(t *testing.T) {
+	tests := []struct {
+		name string
+		data string
+		dev  *DevRelease
+	}{
+		{
+			name: "dev present",
+			data: `{"versions":{"1.38.0":{"releaseDate":"2025-01-15"}},"sha256sums":{},"dev":{"releaseDate":"2025-01-20","commitSha":"92c6cb58","tarballs":{"linux/amd64":"https://example.com/dev.tar.xz"}}}`,
+			dev: &DevRelease{
+				ReleaseDate: "2025-01-20",
+				CommitSha:   "92c6cb58",
+				Tarballs:    map[Platform]TarballURL{"linux/amd64": "https://example.com/dev.tar.xz"},
+			},
+		},
+		{
+			name: "dev absent",
+			data: `{"versions":{"1.38.0":{"releaseDate":"2025-01-15"}},"sha256sums":{}}`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var rv ReleaseVersions
+			require.NoError(t, json.Unmarshal([]byte(tt.data), &rv))
+			require.Equal(t, tt.dev, rv.Dev)
+		})
+	}
+}
 
 func TestNewVersion(t *testing.T) {
 	tests := []struct {
@@ -16,6 +46,14 @@ func TestNewVersion(t *testing.T) {
 		expected    Version
 		expectedErr string
 	}{
+		{
+			input:    "dev",
+			expected: Dev,
+		},
+		{
+			input:    "dev-latest",
+			expected: DevLatest,
+		},
 		{
 			input:    "1.19",
 			expected: MinorVersion("1.19"),


### PR DESCRIPTION
Before this, testing pre-release Envoy with func-e meant compiling it yourself or using Docker, which only worked on Linux. Now you can install and run dev builds on all platforms the same way you would any tagged version.

```bash
$ ENVOY_VERSION=dev func-e run --version                                                              
downloading https://archive.tetratelabs.io/envoy/download/dev/envoy-dev-darwin-arm64.tar.xz
starting: /Users/codefromthecrypt/.local/share/func-e/envoy-versions/dev/bin/envoy with logs in /Users/codefromthecrypt/.local/state/func-e/envoy-runs/20260518_170024_807

/Users/codefromthecrypt/.local/share/func-e/envoy-versions/dev/bin/envoy  version: abbadd905fa486ff1085cf3bbe4f3b73eb6dd8e0/1.39.0-dev/Clean/RELEASE/BoringSSL

$ func-e versions -a                                                                                  
  dev 2026-05-18 (a8d396eb)
  1.38.0 2026-04-23
  1.37.2 2026-04-10
-- snip--
```

This works because envoy's version manifest was recently updated with a special "dev" key backed by a [daily pipeline job](https://github.com/tetratelabs/archive-envoy/pull/70), which archives linux from envoy's docker image, and builds macos from the same SHA.

## Updating the "dev" build with the "dev-latest" alias.

`dev` installs on demand like all other versions and stays put once pulled. The alias `dev-latest` compares the remote release date against the local install and re-downloads only when the build has changed. `func-e use dev-latest` persists "dev" in the version file, so it is a one-shot refresh, not a stored preference.

## Why Use An Envoy "dev" Build?

Envoy releases are worth the wait, but they land about once a quarter. The dev build is for the gap between “merged” and “released”: you can try current Envoy mainline without building Envoy yourself or relying on a Linux-only Docker workflow.

For example, Envoy 1.39-dev already has new dynamic-module support for request-aware upstream selection. A dynamic module can parse a request, write `selected_backend` or `selected_endpoint` into request state, and have the cluster read it while choosing the upstream host. That removes the need to pass routing decisions through synthetic headers  or route re-selection.

Use dev when you need to test an unreleased feature, validate upgrade impact early, or give feedback before the next Envoy release is cut. Use tagged versions for normal production runs.