### PR TITLE
Fix install.sh to follow curl-sh norms

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ func-e (pronounced funky) makes running [Envoy®](https://www.envoyproxy.io/) ea
 
 The quickest way to try the command-line interface is an in-lined configuration.
 ```bash
-# Download the latest release as /usr/local/bin/func-e https://github.com/tetratelabs/func-e/releases
-$ curl https://func-e.io/install.sh | bash -s -- -b /usr/local/bin
+# Download the latest release https://github.com/tetratelabs/func-e/releases
+$ curl -fsSL https://func-e.io/install.sh | sh
 # Run the admin server on http://localhost:9901
 $ func-e run --config-yaml "admin: {address: {socket_address: {address: '127.0.0.1', port_value: 9901}}}"
 ```

--- a/site/content/_index.md
+++ b/site/content/_index.md
@@ -8,7 +8,7 @@ configuration you would use in production. Each time you end a run, a snapshot o
 your behalf. This makes knowledge sharing and troubleshooting easier, especially when upgrading. Try it out!
 
 ```sh
-curl https://func-e.io/install.sh | bash -s -- -b /usr/local/bin
+curl -fsSL https://func-e.io/install.sh | sh
 func-e run -c /path/to/envoy.yaml
 ```
 

--- a/site/static/install.sh
+++ b/site/static/install.sh
@@ -10,7 +10,7 @@ usage() {
 $this: download go binaries for tetratelabs/func-e
 
 Usage: $this [-b] bindir [-d] [tag]
-  -b sets bindir or installation directory, Defaults to ./bin
+  -b sets bindir or installation directory, Defaults to \$HOME/.local/bin
   -d turns on debug logging
    [tag] is a tag from
    https://github.com/tetratelabs/func-e/releases
@@ -24,10 +24,10 @@ EOF
 }
 
 parse_args() {
-  #BINDIR is ./bin unless set be ENV
+  #BINDIR is $HOME/.local/bin unless set by ENV
   # over-ridden by flag below
 
-  BINDIR=${BINDIR:-./bin}
+  BINDIR=${BINDIR:-$HOME/.local/bin}
   while getopts "b:dh?x" arg; do
     case "$arg" in
       b) BINDIR="$OPTARG" ;;
@@ -60,6 +60,11 @@ execute() {
     log_info "installed ${BINDIR}/${binexe}"
   done
   rm -rf "${tmpdir}"
+  case ":${PATH}:" in
+    *:"${BINDIR}":*) ;;
+    *) log_info "To use func-e, add ${BINDIR} to your \$PATH:"
+       log_info "  export PATH=\"${BINDIR}:\$PATH\"" ;;
+  esac
 }
 get_binaries() {
   case "$PLATFORM" in
@@ -88,19 +93,6 @@ tag_to_version() {
   TAG="$REALTAG"
   VERSION=${TAG#v}
 }
-adjust_format() {
-  # change format (tar.gz or zip) based on OS
-  true
-}
-adjust_os() {
-  # adjust archive name based on OS
-  true
-}
-adjust_arch() {
-  # adjust archive name based on ARCH
-  true
-}
-
 cat /dev/null <<EOF
 ------------------------------------------------------------------------
 https://github.com/client9/shlib - portable posix shell functions
@@ -185,39 +177,18 @@ uname_os_check() {
   os=$(uname_os)
   case "$os" in
     darwin) return 0 ;;
-    dragonfly) return 0 ;;
-    freebsd) return 0 ;;
     linux) return 0 ;;
-    android) return 0 ;;
-    nacl) return 0 ;;
-    netbsd) return 0 ;;
-    openbsd) return 0 ;;
-    plan9) return 0 ;;
-    solaris) return 0 ;;
-    windows) return 0 ;;
   esac
-  log_crit "uname_os_check '$(uname -s)' got converted to '$os' which is not a GOOS value. Please file bug at https://github.com/client9/shlib"
+  log_crit "uname_os_check '$(uname -s)' got converted to '$os' which is not supported. Supported: darwin, linux"
   return 1
 }
 uname_arch_check() {
   arch=$(uname_arch)
   case "$arch" in
-    386) return 0 ;;
     amd64) return 0 ;;
     arm64) return 0 ;;
-    armv5) return 0 ;;
-    armv6) return 0 ;;
-    armv7) return 0 ;;
-    ppc64) return 0 ;;
-    ppc64le) return 0 ;;
-    mips) return 0 ;;
-    mipsle) return 0 ;;
-    mips64) return 0 ;;
-    mips64le) return 0 ;;
-    s390x) return 0 ;;
-    amd64p32) return 0 ;;
   esac
-  log_crit "uname_arch_check '$(uname -m)' got converted to '$arch' which is not a GOARCH value.  Please file bug report at https://github.com/client9/shlib"
+  log_crit "uname_arch_check '$(uname -m)' got converted to '$arch' which is not supported. Supported: amd64, arm64"
   return 1
 }
 untar() {
@@ -299,8 +270,8 @@ hash_sha256() {
     hash=$(shasum -a 256 "$TARGET" 2>/dev/null) || return 1
     echo "$hash" | cut -d ' ' -f 1
   elif is_command openssl; then
-    hash=$(openssl -dst openssl dgst -sha256 "$TARGET") || return 1
-    echo "$hash" | cut -d ' ' -f a
+    hash=$(openssl dgst -sha256 "$TARGET") || return 1
+    echo "$hash" | cut -d ' ' -f 2
   else
     log_crit "hash_sha256 unable to find command to compute sha-256 hash"
     return 1
@@ -355,12 +326,6 @@ parse_args "$@"
 get_binaries
 
 tag_to_version
-
-adjust_format
-
-adjust_os
-
-adjust_arch
 
 log_info "found version: ${VERSION} for ${TAG}/${OS}/${ARCH}"
 


### PR DESCRIPTION
Before this, installing func-e required an awkward invocation that hardcoded a system directory needing root:
```sh
curl https://func-e.io/install.sh | bash -s -- -b /usr/local/bin
```

Now it follows curl-sh conventions like Deno, uv, and Poetry:
```sh
$ curl -fsSL https://func-e.io/install.sh | sh
tetratelabs/func-e info installed /Users/you/.local/bin/func-e
tetratelabs/func-e info To use func-e, add /Users/you/.local/bin to your $PATH:
tetratelabs/func-e info   export PATH="/Users/you/.local/bin:$PATH"
```

The default install directory is `$HOME/.local/bin`, the [XDG Base Directory](https://specifications.freedesktop.org/basedir-spec/latest/) standard location for user-installed executables. func-e already uses XDG conventions for its config, data, and state directories. The `-b` flag still works for custom locations.

While here, clean up godownloader boilerplate that bit-rotted since the generator was archived in 2021:
- Fix the openssl hash fallback (garbled command `openssl -dst openssl dgst` and invalid `cut -f a`)
- Remove three no-op `adjust_*` stubs that were never customized
- Narrow OS/arch validation to the four platforms `get_binaries` actually supports (darwin/linux, amd64/arm64)

Fixes #436